### PR TITLE
Store sparsity

### DIFF
--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -26,6 +26,7 @@ SourceFiles
 \*---------------------------------------------------------------------------*/
 #include <ginkgo/ginkgo.hpp>
 #include "IOGKOMatrixHandler.H"
+#include "common.H"
 
 namespace Foam {
 
@@ -75,7 +76,9 @@ void IOGKOMatrixHandler::init_device_matrix(
     auto gkomatrix =
         gko::share(mtx::create(device_exec, gko::dim<2>(nCells, nCells)));
 
+    SIMPLE_TIME(verbose_, convert_coo_to_csr,
     coo_mtx->convert_to(gkomatrix.get());
+    )
 
 
     // if updating system matrix is not needed store ptr in obj registry
@@ -88,8 +91,7 @@ void IOGKOMatrixHandler::init_device_matrix(
         io_col_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_col, db), col_idx);
         io_row_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_row, db), row_idx);
     } else {
-        Info << "!!! matrix has been updated " << endl;
-        // TODO delet old pointer
+        SIMPLE_LOG(verbose_, "Matrix has been updated ");
         gkomatrix_ptr_ = new GKOCSRIOPtr(IOobject(path, db), gkomatrix);
     }
 };

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.H
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.H
@@ -61,6 +61,8 @@ private:
 
     const bool update_init_guess_vector_;
 
+    const bool verbose_;
+
     const bool export_;
 
     mutable label prev_solve_iters_ = 0;
@@ -94,7 +96,8 @@ public:
               db.foundObject<regIOobject>(init_guess_vector_name_)),
           update_init_guess_vector_(
               controlDict.lookupOrDefault<Switch>("updateInitVector", false)),
-
+          verbose_(
+              controlDict.lookupOrDefault<Switch>("verbose", false)),
           export_(controlDict.lookupOrDefault<Switch>("export", false)){};
 
     bool get_sys_matrix_stored() const { return sys_matrix_stored_; };
@@ -109,7 +112,7 @@ public:
                             std::vector<label> &col_idxs_host,
                             std::vector<label> &row_idxs_host,
                             const label nElems, const label nCells,
-                            const bool store) const;
+                            const bool update) const;
 
     std::shared_ptr<mtx> get_gkomatrix() const
     {

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -138,7 +138,7 @@ public:
 
         init_device_matrix(this->matrix().mesh().thisDb(), this->values(),
                            this->col_idxs(), this->row_idxs(), this->nElems(),
-                           this->nCells(), !get_update_sys_matrix());
+                           this->nCells(), get_update_sys_matrix());
     }
 
 


### PR DESCRIPTION
This PR changes how host/device matrix and sparsity pattern are stored.

The matrix is stored on the device in any case now. If a matrix update (default) is requested the host matrix is updated and resorted (currently on the device) and a new gkomatrix is created reusing the former sparsity pattern.