### PR TITLE
Ordered data copy

### DIFF
--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -62,10 +62,10 @@ void IOGKOMatrixHandler::init_device_matrix(
     }
 
     // if system matrix is not stored create it and set shared pointer
-    auto coo_mtx = gko::share(
-        coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells), 
-		        val_array(device_exec, *values_host.get()),
-                        *col_idx.get(), *row_idx.get()));
+    auto coo_mtx =
+        gko::share(coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells),
+                                   val_array(device_exec, *values_host.get()),
+                                   *col_idx.get(), *row_idx.get()));
 
     auto gkomatrix =
         gko::share(mtx::create(device_exec, gko::dim<2>(nCells, nCells)));

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -62,11 +62,9 @@ void IOGKOMatrixHandler::init_device_matrix(
     }
 
     // if system matrix is not stored create it and set shared pointer
-    std::shared_ptr<val_array> values =
-        std::make_shared<val_array>(device_exec, *values_host.get());
-
     auto coo_mtx = gko::share(
-        coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells), *values.get(),
+        coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells), 
+		        val_array(device_exec, *values_host.get()),
                         *col_idx.get(), *row_idx.get()));
 
     auto gkomatrix =

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -31,9 +31,10 @@ SourceFiles
 namespace Foam {
 
 void IOGKOMatrixHandler::init_device_matrix(
-    const objectRegistry &db, std::vector<scalar> &values_host,
-    std::vector<label> &col_idxs_host, std::vector<label> &row_idxs_host,
-    const label nElems, const label nCells, const bool update) const
+    const objectRegistry &db, std::shared_ptr<val_array> values_host,
+    std::shared_ptr<idx_array> col_idxs_host,
+    std::shared_ptr<idx_array> row_idxs_host, const label nElems,
+    const label nCells, const bool update) const
 {
     std::shared_ptr<gko::Executor> device_exec = get_device_executor();
 
@@ -54,31 +55,25 @@ void IOGKOMatrixHandler::init_device_matrix(
     } else {
         // if not stored yet create sparsity pattern from correspondent
         // views
-        auto col_idx_view = idx_array::view(gko::ReferenceExecutor::create(),
-                                            nElems, &col_idxs_host[0]);
-        auto row_idx_view = idx_array::view(gko::ReferenceExecutor::create(),
-                                            nElems, &row_idxs_host[0]);
-
-        // copy sparsity pattern to device and leave it there
-        col_idx = std::make_shared<idx_array>(col_idx_view);
-        col_idx->set_executor(device_exec);
-        row_idx = std::make_shared<idx_array>(row_idx_view);
-        row_idx->set_executor(device_exec);
+        col_idx =
+            std::make_shared<idx_array>(device_exec, *col_idxs_host.get());
+        row_idx =
+            std::make_shared<idx_array>(device_exec, *row_idxs_host.get());
     }
 
     // if system matrix is not stored create it and set shared pointer
+    std::shared_ptr<val_array> values =
+        std::make_shared<val_array>(device_exec, *values_host.get());
+
     auto coo_mtx = gko::share(
-        coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells),
-                        val_array::view(gko::ReferenceExecutor::create(),
-                                        nElems, &values_host[0]),
+        coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells), *values.get(),
                         *col_idx.get(), *row_idx.get()));
 
     auto gkomatrix =
         gko::share(mtx::create(device_exec, gko::dim<2>(nCells, nCells)));
 
     SIMPLE_TIME(verbose_, convert_coo_to_csr,
-    coo_mtx->convert_to(gkomatrix.get());
-    )
+                coo_mtx->convert_to(gkomatrix.get());)
 
 
     // if updating system matrix is not needed store ptr in obj registry

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -41,12 +41,12 @@ void IOGKOMatrixHandler::init_device_matrix(
     if (sys_matrix_stored_ && !update) {
         gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
         return;
-    } 
+    }
 
     if (sys_matrix_stored_ && update) {
         gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
-	gkomatrix_ptr_->get_ptr().reset();
-    } 
+        gkomatrix_ptr_->get_ptr().reset();
+    }
 
     std::shared_ptr<idx_array> col_idx;
     std::shared_ptr<idx_array> row_idx;

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.H
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.H
@@ -35,14 +35,15 @@ SourceFiles
 
 namespace Foam {
 
-using coo_mtx = gko::matrix::Coo<scalar>;
-using mtx = gko::matrix::Csr<scalar>;
-using vec = gko::matrix::Dense<scalar>;
-using val_array = gko::Array<scalar>;
-using idx_array = gko::Array<label>;
 
 class IOGKOMatrixHandler : public IOExecutorHandler {
 private:
+    using coo_mtx = gko::matrix::Coo<scalar>;
+    using mtx = gko::matrix::Csr<scalar>;
+    using vec = gko::matrix::Dense<scalar>;
+    using val_array = gko::Array<scalar>;
+    using idx_array = gko::Array<label>;
+
     const word sys_matrix_name_;
 
     const bool sys_matrix_stored_;
@@ -96,8 +97,7 @@ public:
               db.foundObject<regIOobject>(init_guess_vector_name_)),
           update_init_guess_vector_(
               controlDict.lookupOrDefault<Switch>("updateInitVector", false)),
-          verbose_(
-              controlDict.lookupOrDefault<Switch>("verbose", false)),
+          verbose_(controlDict.lookupOrDefault<Switch>("verbose", false)),
           export_(controlDict.lookupOrDefault<Switch>("export", false)){};
 
     bool get_sys_matrix_stored() const { return sys_matrix_stored_; };
@@ -108,9 +108,9 @@ public:
     };
 
     void init_device_matrix(const objectRegistry &db,
-                            std::vector<scalar> &values_host,
-                            std::vector<label> &col_idxs_host,
-                            std::vector<label> &row_idxs_host,
+                            std::shared_ptr<val_array> values_host,
+                            std::shared_ptr<idx_array> col_idxs_host,
+                            std::shared_ptr<idx_array> row_idxs_host,
                             const label nElems, const label nCells,
                             const bool update) const;
 

--- a/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.C
+++ b/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.C
@@ -42,6 +42,11 @@ void IOSortingIdxHandler::compute_sorting_idxs(
             return std::tie(row_idxs[i1], col_idxs[i1]) <
                    std::tie(row_idxs[i2], col_idxs[i2]);
         });
+
+    auto *tmp_sorting_idxs = sorting_idxs_->clone();
+    for (label i = 0; i < nElems_; i++) {
+        sorting_idxs->operator[](tmp_sorting_idxs->operator[](i)) = i;
+    }
 };
 
 void IOSortingIdxHandler::init_sorting_idxs()

--- a/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.C
+++ b/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.C
@@ -27,10 +27,8 @@ IOSortingIdxHandler::IOSortingIdxHandler(const objectRegistry &db,
 
 
 void IOSortingIdxHandler::compute_sorting_idxs(
-    const std::vector<label> &row_idxs, const std::vector<label> &col_idxs,
-    const label nCells
-
-)
+    const std::shared_ptr<idx_array> row_idxs,
+    const std::shared_ptr<idx_array> col_idxs, const label nCells)
 {
     // sort indexes based on comparing values in v
     // using std::stable_sort instead of std::sort
@@ -39,13 +37,18 @@ void IOSortingIdxHandler::compute_sorting_idxs(
     std::stable_sort(
         sorting_idxs_->data(), &sorting_idxs_->data()[nElems_],
         [this, &row_idxs, &col_idxs, nCells](size_t i1, size_t i2) {
-            return std::tie(row_idxs[i1], col_idxs[i1]) <
-                   std::tie(row_idxs[i2], col_idxs[i2]);
+            return std::tie(row_idxs->get_data()[i1],
+                            col_idxs->get_data()[i1]) <
+                   std::tie(row_idxs->get_data()[i2], col_idxs->get_data()[i2]);
         });
 
-    auto *tmp_sorting_idxs = sorting_idxs_->clone();
+    std::vector<label> tmp_sorting_idxs(nElems_);
     for (label i = 0; i < nElems_; i++) {
-        sorting_idxs->operator[](tmp_sorting_idxs->operator[](i)) = i;
+        tmp_sorting_idxs[i] = sorting_idxs_->operator[](i);
+    }
+
+    for (label i = 0; i < nElems_; i++) {
+        sorting_idxs_->operator[](tmp_sorting_idxs[i]) = i;
     }
 };
 

--- a/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.H
+++ b/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.H
@@ -26,6 +26,7 @@ SourceFiles
 \*---------------------------------------------------------------------------*/
 #ifndef OGL_IOSortingIdxHandler_INCLUDED_H
 #define OGL_IOSortingIdxHandler_INCLUDED_H
+#include <ginkgo/ginkgo.hpp>
 
 #include <vector>
 #include "fvCFD.H"
@@ -35,6 +36,9 @@ SourceFiles
 namespace Foam {
 class IOSortingIdxHandler {
 private:
+    using val_array = gko::Array<scalar>;
+    using idx_array = gko::Array<label>;
+
     const label nElems_;
 
     // if sorting_idxs_ was found in object registry it does not
@@ -53,8 +57,8 @@ public:
 
     void init_sorting_idxs();
 
-    void compute_sorting_idxs(const std::vector<label> &row_idxs,
-                              const std::vector<label> &col_idxs,
+    void compute_sorting_idxs(const std::shared_ptr<idx_array> row_idxs,
+                              const std::shared_ptr<idx_array> col_idxs,
                               const label nCells);
 
     bool get_sort() const { return sort_; }

--- a/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.H
+++ b/IOHandler/IOSortingIdxHandler/IOSortingIdxHandler.H
@@ -49,7 +49,7 @@ private:
     // should be sorted
     const bool sort_;
 
-    IOField<label> *sorting_idxs_ = NULL;
+    mutable IOField<label> *sorting_idxs_ = NULL;
 
 public:
     IOSortingIdxHandler(const objectRegistry &db, const label nElems,
@@ -67,7 +67,7 @@ public:
 
     bool get_is_sorted() const { return is_sorted_; }
 
-    const IOField<label> *get_sorting_idxs() const { return sorting_idxs_; }
+    IOField<label> *get_sorting_idxs() const { return sorting_idxs_; }
 };
 }  // namespace Foam
 

--- a/common/common.H
+++ b/common/common.H
@@ -36,6 +36,8 @@ SourceFiles
 
 #include <ginkgo/ginkgo.hpp>
 #include <map>
+#include <list>
+#include <iterator>
 
 namespace Foam {
 using mtx = gko::matrix::Csr<scalar>;
@@ -103,38 +105,67 @@ public:
         row_idxs_ = std::make_shared<idx_array>(
             gko::ReferenceExecutor::create(), nElems());
 
-        // fill vectors
-        // unsorted
-        for (label i = 0; i < nNeighbours(); ++i) {
-            row_idxs_->get_data()[i] = this->matrix().lduAddr().lowerAddr()[i];
-            col_idxs_->get_data()[i] = this->matrix().lduAddr().upperAddr()[i];
+	auto lower = this->matrix().lduAddr().lowerAddr();
+	auto upper = this->matrix().lduAddr().upperAddr();
 
-            row_idxs_->get_data()[i+nCells()+nNeighbours()] = this->matrix().lduAddr().upperAddr()[i];
-            col_idxs_->get_data()[i+nCells()+nNeighbours()] = this->matrix().lduAddr().lowerAddr()[i];
-        }
+	auto rows =row_idxs_->get_data();
+	auto cols =col_idxs_->get_data();
 
-        for (label i = 0; i < nCells() ; ++i) {
-            col_idxs_->get_data()[i+nNeighbours()] = i;
-            row_idxs_->get_data()[i+nNeighbours()] = i;
-        }
+	label element_ctr = 0;
+	label upper_ctr = 0;
+	std::list<std::pair<label,label>> lower_stack;
+	auto lower_pos = lower_stack.begin();
+	for (label row=0; row<nCells(); row++) {
+		// add lower elements
+		// for now just scan till current upper ctr
+		if (!lower_stack.empty()) {
+			while (lower_stack.front().first == row ) {
+				rows[element_ctr] = lower_stack.front().first;
+				cols[element_ctr] = lower_stack.front().second;
+				element_ctr++;
+				lower_stack.pop_front();
+			}
+		}
+		// since upper elements seem to be sorted 
+		// jumping back is only needed after inserting 
+		// all upper coeffs
+		// also after poping the front the iterator
+		// needs to be refreshed
+		lower_pos = lower_stack.begin();
 
+		// add diagonal elemnts
+		rows[element_ctr] = row;
+		cols[element_ctr] = row;
+		element_ctr++;
+
+		// add upper elemnts
+		while (lower[upper_ctr] == row && upper_ctr < nNeighbours_ ) {
+			label row = lower[upper_ctr]; 
+			label col = upper[upper_ctr];
+			rows[element_ctr] = row;
+			cols[element_ctr] = col; 
+
+			// insert into lower_stack
+			// find insert position
+			if (!lower_stack.empty()) {
+				while (
+				     lower_pos != lower_stack.end()
+				 &&		lower_pos->first <= col
+				    ) {
+					lower_pos++;
+				}
+			}
+		        lower_stack.emplace(col,row);
+			lower_pos++;
+
+			element_ctr++;
+			upper_ctr++;
+		}
+	}
     }
 
-    void sort_host_matrix_sparsity_pattern(
-        const IOField<label> *sorting_idxs) const
-    {
-        idx_array tmp_col_idxs{*col_idxs_.get()};
-        idx_array tmp_row_idxs{*row_idxs_.get()};
 
-        for (label i = 0; i < nElems(); i++) {
-            label j = sorting_idxs->operator[](i);
-            col_idxs_->get_data()[j] = tmp_col_idxs.get_data()[i];
-            row_idxs_->get_data()[j] = tmp_row_idxs.get_data()[i];
-        }
-    };
-
-
-    void update_host_matrix_data(const IOField<label> *sorting_idxs) const
+    void update_host_matrix_data() const
     {
         label nCells_ = nCells();
         label nNeighbours_ = nNeighbours();
@@ -143,20 +174,33 @@ public:
                                               nElems());
 
 	auto values = values_->get_data();
+	auto diag = this->matrix().diag();
 	auto lower = this->matrix().lower();
 	auto upper = this->matrix().upper();
-        for (label i = 0; i < nNeighbours(); ++i) {
-            values[sorting_idxs->operator[](i)] = lower[i];
-            values[sorting_idxs->operator[](
-                i + nCells_ + nNeighbours_)] = upper[i];
-        }
+	auto lower_idx = this->matrix().lduAddr().lowerAddr();
+	auto upper_idx = this->matrix().lduAddr().upperAddr();
+	label element_ctr = 0;
+	label upper_ctr = 0;
+	label lower_ctr = 0;
+	for (label row=0; row<nCells(); row++) {
+		// add lower elements
+		while (upper_idx[lower_ctr] == row && lower_ctr < nNeighbours_ ) {
+			values[element_ctr] = lower[lower_ctr]; 
+			element_ctr++;
+			lower_ctr++;
+		}
 
-        // TODO does this even need to look up the sorting?
-        // d values could be added to l or u values
-	auto diag = this->matrix().diag();
-        for (label i = 0; i < nCells(); ++i) {
-            values[sorting_idxs->operator[](i + nNeighbours_)] = diag[i];
-        }
+		// add diagonal elemnts
+		values[element_ctr] = diag[row];
+		element_ctr++;
+
+		// add upper elemnts
+		while (lower_idx[upper_ctr] == row && upper_ctr < nNeighbours_ ) {
+			values[element_ctr] = upper[upper_ctr]; 
+			element_ctr++;
+			upper_ctr++;
+		}
+	}
     };
 
     label nCells() const { return nCells_; };

--- a/common/common.H
+++ b/common/common.H
@@ -108,24 +108,23 @@ public:
         for (label i = 0; i < nNeighbours(); ++i) {
             row_idxs_->get_data()[i] = this->matrix().lduAddr().lowerAddr()[i];
             col_idxs_->get_data()[i] = this->matrix().lduAddr().upperAddr()[i];
+
+            row_idxs_->get_data()[i+nCells()+nNeighbours()] = this->matrix().lduAddr().upperAddr()[i];
+            col_idxs_->get_data()[i+nCells()+nNeighbours()] = this->matrix().lduAddr().lowerAddr()[i];
         }
 
-        for (label i = nNeighbours(); i < nCells() + nNeighbours(); ++i) {
-            col_idxs_->get_data()[i] = i;
-            row_idxs_->get_data()[i] = i;
+        for (label i = 0; i < nCells() ; ++i) {
+            col_idxs_->get_data()[i+nNeighbours()] = i;
+            row_idxs_->get_data()[i+nNeighbours()] = i;
         }
 
-        for (label i = nCells() + nNeighbours(); i < nElems(); ++i) {
-            row_idxs_->get_data()[i] = this->matrix().lduAddr().upperAddr()[i];
-            col_idxs_->get_data()[i] = this->matrix().lduAddr().lowerAddr()[i];
-        }
     }
 
     void sort_host_matrix_sparsity_pattern(
         const IOField<label> *sorting_idxs) const
     {
-        idx_array tmp_col_idxs{col_idxs_};
-        idx_array tmp_row_idxs{row_idxs_};
+        idx_array tmp_col_idxs{*col_idxs_.get()};
+        idx_array tmp_row_idxs{*row_idxs_.get()};
 
         for (label i = 0; i < nElems(); i++) {
             label j = sorting_idxs->operator[](i);
@@ -146,10 +145,11 @@ public:
         for (label i = 0; i < nNeighbours(); ++i) {
             values_->get_data()[sorting_idxs->operator[](i)] =
                 this->matrix().lower()[i];
+        }
+        for (label i = 0; i < nNeighbours(); ++i) {
             values_->get_data()[sorting_idxs->operator[](
                 i + nCells_ + nNeighbours_)] = this->matrix().upper()[i];
         }
-
         // TODO does this even need to look up the sorting?
         // d values could be added to l or u values
         for (label i = 0; i < nCells(); ++i) {

--- a/common/common.H
+++ b/common/common.H
@@ -38,6 +38,8 @@ SourceFiles
 #include <map>
 
 namespace Foam {
+using mtx = gko::matrix::Csr<scalar>;
+using vec = gko::matrix::Dense<scalar>;
 
 #define SIMPLE_LOG(VERBOSE, MSG)                       \
     if (VERBOSE) {                                     \
@@ -59,17 +61,20 @@ namespace Foam {
 template <class MatrixType>
 class HostMatrix : public MatrixType::solver {
 private:
+    using val_array = gko::Array<scalar>;
+    using idx_array = gko::Array<label>;
+
     const label nCells_;
 
     const label nNeighbours_;
 
     const label nElems_;
 
-    mutable std::vector<scalar> values_;
+    mutable std::shared_ptr<val_array> values_;
 
-    mutable std::vector<label> col_idxs_;
+    mutable std::shared_ptr<idx_array> col_idxs_;
 
-    mutable std::vector<label> row_idxs_;
+    mutable std::shared_ptr<idx_array> row_idxs_;
 
 public:
     HostMatrix(const word &fieldName, const MatrixType &matrix,
@@ -92,84 +97,64 @@ public:
 
     void init_host_sparsity_pattern() const
     {
-        col_idxs_.resize(0);
-        row_idxs_.resize(0);
+        col_idxs_ = std::make_shared<idx_array>(
+            gko::ReferenceExecutor::create(), nElems());
 
-        col_idxs_.reserve(nElems());
-        row_idxs_.reserve(nElems());
+        row_idxs_ = std::make_shared<idx_array>(
+            gko::ReferenceExecutor::create(), nElems());
 
         // fill vectors
         // unsorted
         for (label i = 0; i < nNeighbours(); ++i) {
-            row_idxs_.push_back(this->matrix().lduAddr().lowerAddr()[i]);
-            col_idxs_.push_back(this->matrix().lduAddr().upperAddr()[i]);
+            row_idxs_->get_data()[i] = this->matrix().lduAddr().lowerAddr()[i];
+            col_idxs_->get_data()[i] = this->matrix().lduAddr().upperAddr()[i];
         }
 
-        for (label i = 0; i < nCells(); ++i) {
-            col_idxs_.push_back(i);
-            row_idxs_.push_back(i);
+        for (label i = nNeighbours(); i < nCells() + nNeighbours(); ++i) {
+            col_idxs_->get_data()[i] = i;
+            row_idxs_->get_data()[i] = i;
         }
 
-        for (label i = 0; i < nNeighbours(); ++i) {
-            row_idxs_.push_back(this->matrix().lduAddr().upperAddr()[i]);
-            col_idxs_.push_back(this->matrix().lduAddr().lowerAddr()[i]);
+        for (label i = nCells() + nNeighbours(); i < nElems(); ++i) {
+            row_idxs_->get_data()[i] = this->matrix().lduAddr().upperAddr()[i];
+            col_idxs_->get_data()[i] = this->matrix().lduAddr().lowerAddr()[i];
         }
     }
 
     void sort_host_matrix_sparsity_pattern(
         const IOField<label> *sorting_idxs) const
     {
-        std::vector<label> tmp_col_idxs(nElems());
-        std::vector<label> tmp_row_idxs(nElems());
-
-        for (label i = 0; i < nElems(); i++) tmp_col_idxs[i] = col_idxs_[i];
-        for (label i = 0; i < nElems(); i++) tmp_row_idxs[i] = row_idxs_[i];
+        idx_array tmp_col_idxs{col_idxs_};
+        idx_array tmp_row_idxs{row_idxs_};
 
         for (label i = 0; i < nElems(); i++) {
             label j = sorting_idxs->operator[](i);
-            col_idxs_[j] = tmp_col_idxs[i];
-            row_idxs_[j] = tmp_row_idxs[i];
+            col_idxs_->get_data()[j] = tmp_col_idxs.get_data()[i];
+            row_idxs_->get_data()[j] = tmp_row_idxs.get_data()[i];
         }
     };
 
 
     void update_host_matrix_data(const IOField<label> *sorting_idxs) const
     {
-        // reset
-        // vectors
-        values_.resize(nElems());
-
-        // values_.reserve(nElems());
-
-        // fill vectors
-        // unsorted
         label nCells_ = nCells();
         label nNeighbours_ = nNeighbours();
 
+        values_ = std::make_shared<val_array>(gko::ReferenceExecutor::create(),
+                                              nElems());
+
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_[sorting_idxs->operator[](i)] = this->matrix().lower()[i];
+            values_->get_data()[sorting_idxs->operator[](i)] =
+                this->matrix().lower()[i];
+            values_->get_data()[sorting_idxs->operator[](
+                i + nCells_ + nNeighbours_)] = this->matrix().upper()[i];
         }
 
+        // TODO does this even need to look up the sorting?
+        // d values could be added to l or u values
         for (label i = 0; i < nCells(); ++i) {
-            values_[sorting_idxs->operator[](i + nNeighbours_)] =
+            values_->get_data()[sorting_idxs->operator[](i + nNeighbours_)] =
                 this->matrix().diag()[i];
-        }
-
-        for (label i = 0; i < nNeighbours(); ++i) {
-            values_[sorting_idxs->operator[](i + nCells_ + nNeighbours_)] =
-                this->matrix().upper()[i];
-        }
-    };
-
-    void sort_host_matrix_data(const IOField<label> *sorting_idxs) const
-    {
-        std::vector<scalar> tmp_values(nElems());
-
-        for (label i = 0; i < nElems(); i++) tmp_values[i] = values_[i];
-
-        for (label i = 0; i < nElems(); i++) {
-            label j = sorting_idxs->operator[](i);
-            values_[i] = tmp_values[j];
         }
     };
 
@@ -179,11 +164,11 @@ public:
 
     label nNeighbours() const { return nNeighbours_; };
 
-    std::vector<scalar> &values() const { return values_; };
+    std::shared_ptr<val_array> values() const { return values_; };
 
-    std::vector<label> &col_idxs() const { return col_idxs_; };
+    std::shared_ptr<idx_array> col_idxs() const { return col_idxs_; };
 
-    std::vector<label> &row_idxs() const { return row_idxs_; };
+    std::shared_ptr<idx_array> row_idxs() const { return row_idxs_; };
 };
 
 void export_system(const word fieldName, const mtx *A, const vec *x,

--- a/common/common.H
+++ b/common/common.H
@@ -35,9 +35,9 @@ SourceFiles
 #include "../common/StoppingCriterion.H"
 
 #include <ginkgo/ginkgo.hpp>
-#include <map>
-#include <list>
 #include <iterator>
+#include <list>
+#include <map>
 
 namespace Foam {
 using mtx = gko::matrix::Csr<scalar>;
@@ -97,7 +97,7 @@ public:
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
           nElems_(nCells_ + 2 * nNeighbours_){};
 
-    void init_host_sparsity_pattern(IOField<label>* sorting_idxs) const
+    void init_host_sparsity_pattern(IOField<label> *sorting_idxs) const
     {
         col_idxs_ = std::make_shared<idx_array>(
             gko::ReferenceExecutor::create(), nElems());
@@ -105,48 +105,53 @@ public:
         row_idxs_ = std::make_shared<idx_array>(
             gko::ReferenceExecutor::create(), nElems());
 
-	auto lower = this->matrix().lduAddr().lowerAddr();
-	auto upper = this->matrix().lduAddr().upperAddr();
+        auto lower = this->matrix().lduAddr().lowerAddr();
+        auto upper = this->matrix().lduAddr().upperAddr();
 
-	auto rows =row_idxs_->get_data();
-	auto cols =col_idxs_->get_data();
+        auto rows = row_idxs_->get_data();
+        auto cols = col_idxs_->get_data();
 
-	label element_ctr = 0;
-	label upper_ctr = 0;
-	std::vector<std::vector<std::pair<label,label>>> lower_stack(nNeighbours_);
-	for (label row=0; row<nCells(); row++) {
-		// add lower elements
-		// for now just scan till current upper ctr
-		if (!lower_stack[row].empty()) {
-			for (const auto &element : lower_stack[row] ) {
-				rows[element_ctr] = element.first;
-				cols[element_ctr] = element.second;
-				element_ctr++;
-			}
-		}
+        label element_ctr = 0;
+        label upper_ctr = 0;
+        label lower_ctr = 0;
+        std::vector<std::vector<std::pair<label, label>>> lower_stack(
+            nNeighbours_);
+        for (label row = 0; row < nCells(); row++) {
+            // add lower elements
+            // for now just scan till current upper ctr
+            if (!lower_stack[row].empty()) {
+                for (const auto &element : lower_stack[row]) {
+                    rows[element_ctr] = element.first;
+                    cols[element_ctr] = element.second;
+                    sorting_idxs->operator[](lower_ctr + nNeighbours_) =
+                        element_ctr;
+                    lower_ctr++;
+                    element_ctr++;
+                }
+            }
 
-		// add diagonal elemnts
-		rows[element_ctr] = row;
-		cols[element_ctr] = row;
-		element_ctr++;
-		sorting_idxs->operator[](nNeighbours_ + row) = element_ctr;
+            // add diagonal elemnts
+            rows[element_ctr] = row;
+            cols[element_ctr] = row;
+            element_ctr++;
+            sorting_idxs->operator[](2 * nNeighbours_ + row) = element_ctr;
 
-		// add upper elemnts
-		while (lower[upper_ctr] == row && upper_ctr < nNeighbours_ ) {
-			label row = lower[upper_ctr]; 
-			label col = upper[upper_ctr];
-			rows[element_ctr] = row;
-			cols[element_ctr] = col; 
+            // add upper elemnts
+            while (lower[upper_ctr] == row && upper_ctr < nNeighbours_) {
+                label row = lower[upper_ctr];
+                label col = upper[upper_ctr];
+                rows[element_ctr] = row;
+                cols[element_ctr] = col;
 
-			// insert into lower_stack
-			// find insert position
-			lower_stack[col].emplace_back(col,row);
-			sorting_idxs->operator[](upper_ctr) = element_ctr;
+                // insert into lower_stack
+                // find insert position
+                lower_stack[col].emplace_back(col, row);
+                sorting_idxs->operator[](upper_ctr) = element_ctr;
 
-			element_ctr++;
-			upper_ctr++;
-		}
-	}
+                element_ctr++;
+                upper_ctr++;
+            }
+        }
     }
 
 
@@ -158,47 +163,32 @@ public:
         values_ = std::make_shared<val_array>(gko::ReferenceExecutor::create(),
                                               nElems());
 
-	auto values = values_->get_data();
-	auto diag = this->matrix().diag();
-	auto lower = this->matrix().lower();
-	auto upper = this->matrix().upper();
-	auto lower_idx = this->matrix().lduAddr().lowerAddr();
-	auto upper_idx = this->matrix().lduAddr().upperAddr();
-	label element_ctr = 0;
-	label upper_ctr = 0;
-	label lower_ctr = 0;
-	for (label row=0; row<nCells(); row++) {
-		// add lower elements
-		while (upper_idx[lower_ctr] == row && lower_ctr < nNeighbours_ ) {
-			values[element_ctr] = lower[lower_ctr]; 
-			element_ctr++;
-			lower_ctr++;
-		}
+        auto values = values_->get_data();
+        auto lower = this->matrix().lower();
+        auto upper = this->matrix().upper();
+        for (label i = 0; i < nNeighbours(); ++i) {
+            values[sorting_idxs->operator[](i)] = upper[i];
+            values[sorting_idxs->operator[](i + nNeighbours_)] = lower[i];
+        }
 
-		// add diagonal elemnts
-		values[element_ctr] = diag[row];
-		element_ctr++;
-
-		// add upper elemnts
-		while (lower_idx[upper_ctr] == row && upper_ctr < nNeighbours_ ) {
-			values[element_ctr] = upper[upper_ctr]; 
-			element_ctr++;
-			upper_ctr++;
-		}
-	}
+        auto diag = this->matrix().diag();
+        for (label i = 0; i < nCells(); ++i) {
+            values[sorting_idxs->operator[](i + 2 * nNeighbours_)] = diag[i];
+        }
     };
+};
 
-    label nCells() const { return nCells_; };
+label nCells() const { return nCells_; };
 
-    label nElems() const { return nElems_; };
+label nElems() const { return nElems_; };
 
-    label nNeighbours() const { return nNeighbours_; };
+label nNeighbours() const { return nNeighbours_; };
 
-    std::shared_ptr<val_array> values() const { return values_; };
+std::shared_ptr<val_array> values() const { return values_; };
 
-    std::shared_ptr<idx_array> col_idxs() const { return col_idxs_; };
+std::shared_ptr<idx_array> col_idxs() const { return col_idxs_; };
 
-    std::shared_ptr<idx_array> row_idxs() const { return row_idxs_; };
+std::shared_ptr<idx_array> row_idxs() const { return row_idxs_; };
 };
 
 void export_system(const word fieldName, const mtx *A, const vec *x,

--- a/common/common.H
+++ b/common/common.H
@@ -97,7 +97,7 @@ public:
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
           nElems_(nCells_ + 2 * nNeighbours_){};
 
-    void init_host_sparsity_pattern() const
+    void init_host_sparsity_pattern(IOField<label>* sorting_idxs) const
     {
         col_idxs_ = std::make_shared<idx_array>(
             gko::ReferenceExecutor::create(), nElems());
@@ -113,30 +113,23 @@ public:
 
 	label element_ctr = 0;
 	label upper_ctr = 0;
-	std::list<std::pair<label,label>> lower_stack;
-	auto lower_pos = lower_stack.begin();
+	std::vector<std::vector<std::pair<label,label>>> lower_stack(nNeighbours_);
 	for (label row=0; row<nCells(); row++) {
 		// add lower elements
 		// for now just scan till current upper ctr
-		if (!lower_stack.empty()) {
-			while (lower_stack.front().first == row ) {
-				rows[element_ctr] = lower_stack.front().first;
-				cols[element_ctr] = lower_stack.front().second;
+		if (!lower_stack[row].empty()) {
+			for (const auto &element : lower_stack[row] ) {
+				rows[element_ctr] = element.first;
+				cols[element_ctr] = element.second;
 				element_ctr++;
-				lower_stack.pop_front();
 			}
 		}
-		// since upper elements seem to be sorted 
-		// jumping back is only needed after inserting 
-		// all upper coeffs
-		// also after poping the front the iterator
-		// needs to be refreshed
-		lower_pos = lower_stack.begin();
 
 		// add diagonal elemnts
 		rows[element_ctr] = row;
 		cols[element_ctr] = row;
 		element_ctr++;
+		sorting_idxs->operator[](nNeighbours_ + row) = element_ctr;
 
 		// add upper elemnts
 		while (lower[upper_ctr] == row && upper_ctr < nNeighbours_ ) {
@@ -147,16 +140,8 @@ public:
 
 			// insert into lower_stack
 			// find insert position
-			if (!lower_stack.empty()) {
-				while (
-				     lower_pos != lower_stack.end()
-				 &&		lower_pos->first <= col
-				    ) {
-					lower_pos++;
-				}
-			}
-		        lower_stack.emplace(col,row);
-			lower_pos++;
+			lower_stack[col].emplace_back(col,row);
+			sorting_idxs->operator[](upper_ctr) = element_ctr;
 
 			element_ctr++;
 			upper_ctr++;
@@ -165,7 +150,7 @@ public:
     }
 
 
-    void update_host_matrix_data() const
+    void update_host_matrix_data(const IOField<label> *sorting_idxs) const
     {
         label nCells_ = nCells();
         label nNeighbours_ = nNeighbours();

--- a/common/common.H
+++ b/common/common.H
@@ -142,19 +142,20 @@ public:
         values_ = std::make_shared<val_array>(gko::ReferenceExecutor::create(),
                                               nElems());
 
+	auto values = values_->get_data();
+	auto lower = this->matrix().lower();
+	auto upper = this->matrix().upper();
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_->get_data()[sorting_idxs->operator[](i)] =
-                this->matrix().lower()[i];
+            values[sorting_idxs->operator[](i)] = lower[i];
+            values[sorting_idxs->operator[](
+                i + nCells_ + nNeighbours_)] = upper[i];
         }
-        for (label i = 0; i < nNeighbours(); ++i) {
-            values_->get_data()[sorting_idxs->operator[](
-                i + nCells_ + nNeighbours_)] = this->matrix().upper()[i];
-        }
+
         // TODO does this even need to look up the sorting?
         // d values could be added to l or u values
+	auto diag = this->matrix().diag();
         for (label i = 0; i < nCells(); ++i) {
-            values_->get_data()[sorting_idxs->operator[](i + nNeighbours_)] =
-                this->matrix().diag()[i];
+            values[sorting_idxs->operator[](i + nNeighbours_)] = diag[i];
         }
     };
 

--- a/common/common.H
+++ b/common/common.H
@@ -133,26 +133,31 @@ public:
     };
 
 
-    void update_host_matrix_data() const
+    void update_host_matrix_data(const IOField<label> *sorting_idxs) const
     {
         // reset
         // vectors
-        values_.resize(0);
+        values_.resize(nElems());
 
-        values_.reserve(nElems());
+        // values_.reserve(nElems());
 
         // fill vectors
         // unsorted
+        label nCells_ = nCells();
+        label nNeighbours_ = nNeighbours();
+
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_.push_back(this->matrix().lower()[i]);
+            values_[sorting_idxs->operator[](i)] = this->matrix().lower()[i];
         }
 
         for (label i = 0; i < nCells(); ++i) {
-            values_.push_back(this->matrix().diag()[i]);
+            values_[sorting_idxs->operator[](i + nNeighbours_)] =
+                this->matrix().diag()[i];
         }
 
         for (label i = 0; i < nNeighbours(); ++i) {
-            values_.push_back(this->matrix().upper()[i]);
+            values_[sorting_idxs->operator[](i + nCells_ + nNeighbours_)] =
+                this->matrix().upper()[i];
         }
     };
 

--- a/common/common.H
+++ b/common/common.H
@@ -127,8 +127,8 @@ public:
 
         for (label i = 0; i < nElems(); i++) {
             label j = sorting_idxs->operator[](i);
-            col_idxs_[i] = tmp_col_idxs[j];
-            row_idxs_[i] = tmp_row_idxs[j];
+            col_idxs_[j] = tmp_col_idxs[i];
+            row_idxs_[j] = tmp_row_idxs[i];
         }
     };
 

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -98,18 +98,8 @@ public:
         bool stored = get_sys_matrix_stored();
         if (!stored) {
             SIMPLE_TIME(verbose_, init_host_sparsity_pattern,
-                        this->init_host_sparsity_pattern();)
+                        this->init_host_sparsity_pattern(this->get_sorting_idxs());)
 
-            SIMPLE_LOG(verbose_,
-                       "matrix is not yet sorted, compute sorting idxs")
-            SIMPLE_TIME(
-                verbose_, compute_sort,
-                this->compute_sorting_idxs(this->row_idxs(), this->col_idxs(),
-                                           this->nCells());)
-
-            SIMPLE_TIME(
-                verbose_, sort_host_sparsity_pattern,
-                this->sort_host_matrix_sparsity_pattern(this->get_sorting_idxs());)
 
             SIMPLE_LOG(verbose_, "matrix not stored update host matrix")
             SIMPLE_TIME(
@@ -125,7 +115,6 @@ public:
                 SIMPLE_TIME(
                     verbose_, exp_update_host_mtx,
                     this->update_host_matrix_data(this->get_sorting_idxs());)
-                SIMPLE_LOG(verbose_, "host matrix needs to be resorted")
             }
         }
 

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -47,6 +47,9 @@ class lduLduBase : public HostMatrix<MatrixType>,
                    public IOGKOMatrixHandler,
                    public IOPreconditioner {
 private:
+    using val_array = gko::Array<scalar>;
+    using idx_array = gko::Array<label>;
+    using mtx = gko::matrix::Csr<scalar>;
     using vec = gko::matrix::Dense<scalar>;
     const dictionary &solverControls_;
     const bool verbose_;

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -97,9 +97,17 @@ public:
             SIMPLE_TIME(verbose_, init_host_sparsity_pattern,
                         this->init_host_sparsity_pattern();)
 
+            SIMPLE_LOG(verbose_,
+                       "matrix is not yet sorted, compute sorting idxs")
+            SIMPLE_TIME(
+                verbose_, compute_sort,
+                this->compute_sorting_idxs(this->row_idxs(), this->col_idxs(),
+                                           this->nCells());)
+
             SIMPLE_LOG(verbose_, "matrix not stored update host matrix")
-            SIMPLE_TIME(verbose_, update_host_mtx,
-                        this->update_host_matrix_data();)
+            SIMPLE_TIME(
+                verbose_, update_host_mtx,
+                this->update_host_matrix_data(this->get_sorting_idxs());)
         } else {
             // if sys_matrix is  stored updating is only neccesary
             // when requested explictly
@@ -107,33 +115,11 @@ public:
                 SIMPLE_LOG(
                     verbose_,
                     "matrix is stored and update of host matrix requested")
-                SIMPLE_TIME(verbose_, exp_update_host_mtx,
-                            this->update_host_matrix_data();)
-                SIMPLE_LOG(verbose_, "host matrix needs to be resorted")
                 SIMPLE_TIME(
-                    verbose_, sort_host_mtx,
-                    this->sort_host_matrix_data(this->get_sorting_idxs());)
+                    verbose_, exp_update_host_mtx,
+                    this->update_host_matrix_data(this->get_sorting_idxs());)
+                SIMPLE_LOG(verbose_, "host matrix needs to be resorted")
             }
-        }
-
-        // after updating the host matrix the host matrix needs to be sorted
-        if (!get_is_sorted()) {
-            SIMPLE_LOG(verbose_,
-                       "matrix is not yet sorted, compute sorting idxs")
-            SIMPLE_TIME(
-                verbose_, compute_sort,
-                this->compute_sorting_idxs(this->row_idxs(), this->col_idxs(),
-                                           this->nCells());)
-        }
-
-        if (!stored && get_sort()) {
-            SIMPLE_LOG(verbose_,
-                       "matrix is not yet sorted, sorting host matrix")
-            SIMPLE_TIME(
-                verbose_, sort_host_mtx_sparsity_pattern,
-                this->sort_host_matrix_sparsity_pattern(get_sorting_idxs());)
-            SIMPLE_TIME(verbose_, sort_host_mtx,
-                        this->sort_host_matrix_data(this->get_sorting_idxs());)
         }
 
         init_device_matrix(this->matrix().mesh().thisDb(), this->values(),

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -107,6 +107,10 @@ public:
                 this->compute_sorting_idxs(this->row_idxs(), this->col_idxs(),
                                            this->nCells());)
 
+            SIMPLE_TIME(
+                verbose_, sort_host_sparsity_pattern,
+                this->sort_host_matrix_sparsity_pattern(this->get_sorting_idxs());)
+
             SIMPLE_LOG(verbose_, "matrix not stored update host matrix")
             SIMPLE_TIME(
                 verbose_, update_host_mtx,


### PR DESCRIPTION
This PR implements some improvements for the ldu->csr conversion process.
1. It avoids the use of the expensive sorting, since the ldu indices are already sorted.
2. It uses gko::Array over std::vector for the  sorted csr host values, to avoid initialization costs.