### PR TITLE
Init csr once

### DIFF
--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -45,7 +45,13 @@ void IOGKOMatrixHandler::init_device_matrix(
 
     if (sys_matrix_stored_ && update) {
         gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
-        gkomatrix_ptr_->get_ptr().reset();
+        auto gkomatrix = gkomatrix_ptr_->get_ptr();
+        auto values_view =
+            val_array::view(device_exec, nElems, gkomatrix->get_values());
+
+        // move values to device
+        values_view = *values_host.get();
+        return;
     }
 
     std::shared_ptr<idx_array> col_idx;

--- a/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
+++ b/IOHandler/IOGKOMatrixHandler/IOGKOMatrixHandler.C
@@ -38,24 +38,26 @@ void IOGKOMatrixHandler::init_device_matrix(
 {
     std::shared_ptr<gko::Executor> device_exec = get_device_executor();
 
-    if (sys_matrix_stored_ && !update) {
-        gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
-        return;
-    }
+    if (sys_matrix_stored_) {
+        if (!update) {
+            gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
+            return;
+        } else {
+            gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
+            auto gkomatrix = gkomatrix_ptr_->get_ptr();
+            auto values_view =
+                val_array::view(device_exec, nElems, gkomatrix->get_values());
 
-    if (sys_matrix_stored_ && update) {
-        gkomatrix_ptr_ = &db.lookupObjectRef<GKOCSRIOPtr>(sys_matrix_name_);
-        auto gkomatrix = gkomatrix_ptr_->get_ptr();
-        auto values_view =
-            val_array::view(device_exec, nElems, gkomatrix->get_values());
-
-        // move values to device
-        values_view = *values_host.get();
-        return;
+            // copy values to device
+            values_view = *values_host.get();
+            return;
+        }
     }
 
     std::shared_ptr<idx_array> col_idx;
     std::shared_ptr<idx_array> row_idx;
+    // sparsity pattern can be stored, ie from other system_matrices,
+    // even if the corr system matrix
     if (sparsity_pattern_stored_) {
         io_col_idxs_ptr_ =
             &db.lookupObjectRef<GKOIDXIOPtr>(sparsity_pattern_name_cols_);
@@ -87,16 +89,12 @@ void IOGKOMatrixHandler::init_device_matrix(
 
     // if updating system matrix is not needed store ptr in obj registry
     const fileName path = sys_matrix_name_;
-    if (!sys_matrix_stored_) {
-        gkomatrix_ptr_ = new GKOCSRIOPtr(IOobject(path, db), gkomatrix);
-        // in any case store sparsity pattern
-        const fileName path_col = sparsity_pattern_name_cols_;
-        const fileName path_row = sparsity_pattern_name_rows_;
-        io_col_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_col, db), col_idx);
-        io_row_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_row, db), row_idx);
-    } else {
-        gkomatrix_ptr_ = new GKOCSRIOPtr(IOobject(path, db), gkomatrix);
-    }
+    gkomatrix_ptr_ = new GKOCSRIOPtr(IOobject(path, db), gkomatrix);
+    // in any case store sparsity pattern
+    const fileName path_col = sparsity_pattern_name_cols_;
+    const fileName path_row = sparsity_pattern_name_rows_;
+    io_col_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_col, db), col_idx);
+    io_row_idxs_ptr_ = new GKOIDXIOPtr(IOobject(path_row, db), row_idx);
 };
 
 

--- a/common/StoppingCriterion.H
+++ b/common/StoppingCriterion.H
@@ -87,15 +87,13 @@ class StoppingCriterion {
                            std::shared_ptr<vec> x,
                            std::shared_ptr<vec> res) const
         {
-            auto xAvg = gko::initialize<gko::matrix::Dense<scalar>>(
-                1, {0.0}, device_exec);
-
             const label nCells{x->get_size()[0]};
 
             val_array x_array{
                 val_array::view(device_exec, nCells, x->get_values())};
 
-            ::gko::reduce(x_array, xAvg->get_values());
+            auto xAvg = gko::initialize<gko::matrix::Dense<scalar>>(
+                1, {::gko::reduce_add(x_array)}, device_exec);
 
             auto nCells_linOp = gko::initialize<gko::matrix::Dense<scalar>>(
                 1, {scalar(nCells)}, device_exec);


### PR DESCRIPTION
This PR avoids recreating COO/CSR matrices on matrix update, instead a view into the stored device matrix values is created to update the values.