### PR TITLE
Add interface coeffs to matrix size calculation

### DIFF
--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.C
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.C
@@ -64,11 +64,11 @@ std::shared_ptr<gko::matrix::Csr<scalar>> CsrInitFunctor::init() const
         auto rows = row_idxs_.get_global_array();
 
         if (Pstream::master()) {
-            for (int i = 0; i < values->get_num_elems(); i++) {
-                std::cout << "(" << rows->get_const_data()[i] << ","
-                          << cols->get_const_data()[i] << ") "
-                          << values->get_const_data()[i] << std::endl;
-            }
+            // for (int i = 0; i < values->get_num_elems(); i++) {
+            //     std::cout << "(" << rows->get_const_data()[i] << ","
+            //               << cols->get_const_data()[i] << ") "
+            //               << values->get_const_data()[i] << std::endl;
+            // }
             auto coo_mtx = gko::share(
                 coo_mtx::create(device_exec, gko::dim<2>(nCells, nCells),
                                 val_array(device_exec, *values.get()),

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.C
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.C
@@ -35,6 +35,8 @@ void CsrInitFunctor::update(
 {
     if (Pstream::parRun()) {
         if (Pstream::master()) {
+            word msg{"update global csr matrix "};
+            LOG_1(verbose_, msg)
             auto values_view = val_array::view(
                 values_.get_exec_handler().get_device_exec(),
                 values_.get_global_size(), csr_matrix->get_values());
@@ -129,7 +131,8 @@ std::shared_ptr<gko::matrix::Csr<scalar>> CsrInitFunctor::init() const
 
 //     // move frome device
 //     auto psi_view =
-//         val_array::view(ref_exec(), nCells, const_cast<scalar *>(&psi[0]));
+//         val_array::view(ref_exec(), nCells, const_cast<scalar
+//         *>(&psi[0]));
 
 //     psi_view = x_view;
 // }

--- a/DevicePersistent/DevicePersistentArray/DevicePersistentArray.H
+++ b/DevicePersistent/DevicePersistentArray/DevicePersistentArray.H
@@ -173,8 +173,8 @@ public:
     std::shared_ptr<gko::Array<T>> get_global_array() const
     {
         if (Pstream::parRun()) {
+            const word global_name = this->get_name() + "_global";
             if (Pstream::master()) {
-                const word global_name = this->get_name() + "_global";
                 auto &db = this->get_db();
                 bool stored{db.template foundObject<regIOobject>(global_name)};
 
@@ -203,7 +203,7 @@ public:
                 }
             }
 
-            LOG_1(this->get_verbose(), "gather global array")
+            LOG_1(this->get_verbose(), "gather global array: " + global_name)
             global_index_.gather<T>(this->get_persistent_object(),
                                     persistent_object_global_);
             LOG_1(this->get_verbose(), "gather global array done")
@@ -275,25 +275,26 @@ public:
                                              const_cast<T *>(memory));
 
         auto x_view = (Pstream::master())
-                          ? gko::Array<T>::view(exec_.get_device_exec(), global_address.size(),
+                          ? gko::Array<T>::view(exec_.get_device_exec(),
+                                                global_address.size(),
                                                 device_x->get_values())
                           : gko::Array<T>(gko::ReferenceExecutor::create());
         if (Pstream::master()) {
             x_view.set_executor(exec_.get_ref_exec());
 
-	// std::cout << "!!!!!!!!!! x_view before scatter back parallel" << std::endl;
-	// for (int i=0; i< x_view.get_num_elems(); i++) {
-	// 	std::cout << i << ": " << host_view.get_const_data()[i] << std::endl;
-	// }
+            // std::cout << "!!!!!!!!!! x_view before scatter back parallel" <<
+            // std::endl; for (int i=0; i< x_view.get_num_elems(); i++) {
+            // 	std::cout << i << ": " << host_view.get_const_data()[i] <<
+            // std::endl;
+            // }
         }
 
         global_address.scatter(x_view, host_view);
 
-        // std::cout << "!!!!!!!!!! host_view after scatter back parallel" << std::endl;
-        // for (int i=0; i< nCells; i++) {
-        // 	std::cout << i << ": " << host_view.get_const_data()[i] << std::endl;
+        // std::cout << "!!!!!!!!!! host_view after scatter back parallel" <<
+        // std::endl; for (int i=0; i< nCells; i++) { 	std::cout << i << ": "
+        // << host_view.get_const_data()[i] << std::endl;
         // }
-
     }
 
     const ExecutorHandler &get_exec_handler() const { return exec_; }

--- a/DevicePersistent/DevicePersistentBase/DevicePersistentBase.H
+++ b/DevicePersistent/DevicePersistentBase/DevicePersistentBase.H
@@ -121,7 +121,9 @@ public:
             LOG_1(verbose_, msg)
             const fileName path = name_;
 
-            // FIXME this probably leaks memory
+            // NOTE when objectRegistry is deleted delete for every pointer
+            // owned by the registry is called
+            // TODO make shure isOwnedByRegistry returns true
             auto po = new DevicePersistentBase<T>(IOobject(path, db), f.init());
 
             persistent_object_ = po->get_ptr();

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -92,7 +92,7 @@ public:
                     const word field_name)
         : PersistentBase<gko::Executor, ExecutorInitFunctor>(
               solverControls.lookupOrDefault("executor", word("reference")) +
-                  field_name,
+                  +"_" + field_name,
               db,
               ExecutorInitFunctor(
                   solverControls.lookupOrDefault("executor", word("reference")),

--- a/DevicePersistent/IOGlobalIndex/gkoGlobalIndex.H
+++ b/DevicePersistent/IOGlobalIndex/gkoGlobalIndex.H
@@ -401,7 +401,7 @@ public:
                  gko::Array<Value> &localDataOut,
                  const int tag = UPstream::msgType(),
                  const Pstream::commsTypes commsType =
-                     Pstream::commsTypes::blocking) const
+                     Pstream::commsTypes::nonBlocking) const
     {
         scatter(offsets_, comm, procIDs, globalDataIn, localDataOut, tag,
                 commsType);
@@ -414,7 +414,7 @@ public:
                  gko::Array<Value> &localDataOut,
                  const int tag = UPstream::msgType(),
                  const Pstream::commsTypes commsType =
-                     Pstream::commsTypes::blocking) const
+                     Pstream::commsTypes::nonBlocking) const
     {
         scatter(offsets_, UPstream::worldComm,
                 UPstream::procID(UPstream::worldComm), globalDataIn,

--- a/DevicePersistent/IOGlobalIndex/gkoGlobalIndex.H
+++ b/DevicePersistent/IOGlobalIndex/gkoGlobalIndex.H
@@ -210,7 +210,6 @@ public:
             gko::Array<Value>::view(
                 gko::ReferenceExecutor::create(), localDataIn->get_num_elems(),
                 globalDataOut->get_data()) = *localDataIn.get();
-
             if (commsType == Pstream::commsTypes::scheduled ||
                 commsType == Pstream::commsTypes::blocking) {
                 for (label i = 1; i < procIDs.size(); ++i) {
@@ -345,20 +344,14 @@ public:
     {
         if (Pstream::master()) {
             // copy its own data to local array.
-            std::cout << "scatter create view  " << std::endl;
             localDataOut = gko::detail::array_const_cast(
                 gko::Array<Value>::const_view(gko::ReferenceExecutor::create(),
                                               localDataOut.get_num_elems(),
                                               globalDataIn.get_const_data()));
-            std::cout << "scatter create view done  " << std::endl;
-
             if (commsType == Pstream::commsTypes::scheduled ||
                 commsType == Pstream::commsTypes::blocking) {
                 for (label i = 1; i < procIDs.size(); ++i) {
                     label nSubElems = offsets[i + 1] - offsets[i];
-                    std::cout << "scatter to proc " << i << " " << nSubElems
-                              << std::endl;
-
                     OPstream::write(
                         commsType, procIDs[i],
                         reinterpret_cast<const char *>(
@@ -372,9 +365,6 @@ public:
                 // Set up writes
                 for (label i = 1; i < procIDs.size(); ++i) {
                     label nSubElems = offsets[i + 1] - offsets[i];
-                    std::cout << "scatter to proc " << i << " " << nSubElems
-                              << " Elements" << std::endl;
-
                     OPstream::write(
                         commsType, procIDs[i],
                         reinterpret_cast<const char *>(
@@ -386,21 +376,21 @@ public:
                 Pstream::waitRequests(startOfRequests);
             }
         } else {
-            label startOfRequests = Pstream::nRequests();
-            // if (commsType == Pstream::commsTypes::scheduled ||
-            //     commsType == Pstream::commsTypes::blocking) {
-            std::cout << "reading  on " << Pstream::myProcNo() << " of "
-                      << localDataOut.get_num_elems() << " create view done  "
-                      << std::endl;
-
-            IPstream::read(commsType, procIDs[0],
-                           reinterpret_cast<char *>(localDataOut.get_data()),
-                           localDataOut.get_num_elems() * sizeof(Value), tag,
-                           comm);
-            // }
-            Pstream::waitRequests(startOfRequests);
+            if (commsType == Pstream::commsTypes::scheduled ||
+                commsType == Pstream::commsTypes::blocking) {
+                IPstream::read(
+                    commsType, procIDs[0],
+                    reinterpret_cast<char *>(localDataOut.get_data()),
+                    localDataOut.get_num_elems() * sizeof(Value), tag, comm);
+            } else {
+                label startOfRequests = Pstream::nRequests();
+                IPstream::read(
+                    commsType, procIDs[0],
+                    reinterpret_cast<char *>(localDataOut.get_data()),
+                    localDataOut.get_num_elems() * sizeof(Value), tag, comm);
+                Pstream::waitRequests(startOfRequests);
+            }
         }
-        std::cout << "done  on " << Pstream::myProcNo() << std::endl;
     }
 
 
@@ -411,7 +401,7 @@ public:
                  gko::Array<Value> &localDataOut,
                  const int tag = UPstream::msgType(),
                  const Pstream::commsTypes commsType =
-                     Pstream::commsTypes::nonBlocking) const
+                     Pstream::commsTypes::blocking) const
     {
         scatter(offsets_, comm, procIDs, globalDataIn, localDataOut, tag,
                 commsType);
@@ -424,7 +414,7 @@ public:
                  gko::Array<Value> &localDataOut,
                  const int tag = UPstream::msgType(),
                  const Pstream::commsTypes commsType =
-                     Pstream::commsTypes::nonBlocking) const
+                     Pstream::commsTypes::blocking) const
     {
         scatter(offsets_, UPstream::worldComm,
                 UPstream::procID(UPstream::worldComm), globalDataIn,

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -115,7 +115,7 @@ public:
               false,
           },
           values_{fieldName + "_values", db,       exec_,
-                  global_matrix_index_,  verbose_, false},
+                  global_matrix_index_,  verbose_, true},
           col_idxs_{fieldName + "_cols",  db,       exec_,
                     global_matrix_index_, verbose_, false},
           row_idxs_{fieldName + "_rows",  db,       exec_,
@@ -124,13 +124,13 @@ public:
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
             auto other_proc_cell_ids = get_other_proc_cell_ids(interfaces);
             SIMPLE_TIME(
-                true, init_host_sparsity_pattern,
+                verbose_, init_host_sparsity_pattern,
                 init_host_sparsity_pattern(interfaces, other_proc_cell_ids);)
         }
         if (!values_.get_stored() || values_.get_update()) {
             SIMPLE_TIME(
-                true, update_host_matrix_data,
-                update_host_matrix_data(interfaces, interfaceIntCoeffs);)
+                verbose_, update_host_matrix_data,
+                update_host_matrix_data(interfaces, interfaceBouCoeffs);)
         }
     }
 
@@ -158,7 +158,7 @@ public:
               false,
           },
           values_{fieldName + "values", db,       exec_,
-                  global_matrix_index_, verbose_, false},
+                  global_matrix_index_, verbose_, true},
           col_idxs_{fieldName + "cols",   db,       exec_,
                     global_matrix_index_, verbose_, false},
           row_idxs_{fieldName + "rows",   db,       exec_,
@@ -397,7 +397,7 @@ public:
 
     void update_host_matrix_data(
         const lduInterfaceFieldPtrsList &interfaces,
-        const FieldField<Field, scalar> &interfaceIntCoeffs) const
+        const FieldField<Field, scalar> &interfaceBouCoeffs) const
     {
         auto ref_exec = gko::ReferenceExecutor::create();
         // TODO create in ctr
@@ -426,13 +426,17 @@ public:
             if (interfaces.operator()(i) == nullptr) {
                 continue;
             }
-            const label patch_size =
-                interfaces.operator()(i)->interface().faceCells().size();
+            const auto iface{interfaces.operator()(i)};
+            const label patch_size = iface->interface().faceCells().size();
+
+            if (!isA<processorLduInterface>(iface->interface())) {
+                continue;
+            }
 
             for (label cellI = 0; cellI < patch_size; cellI++) {
                 // FIXME use interfaceIntCoeffs from other proccessor
                 values[sorting_interface_idxs[interface_ctr]] =
-                    interfaceIntCoeffs[i][cellI];
+                    interfaceBouCoeffs[i][cellI];
                 interface_ctr++;
             }
         }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -32,6 +32,7 @@ SourceFiles
 #include <vector>
 #include "../DevicePersistentArray/DevicePersistentArray.H"
 #include "../IOGlobalIndex/gkoGlobalIndex.H"
+#include "../common/common.H"
 
 
 namespace Foam {
@@ -58,10 +59,15 @@ private:
 
     const gkoGlobalIndex global_values_index_;
 
+    const gkoGlobalIndex global_interface_index_;
+
     const label verbose_;
 
     // TODO
     mutable PersistentArray<label> ldu_csr_idx_mapping_;
+
+    // TODO
+    mutable PersistentArray<label> ldu_csr_idx_interface_mapping_;
 
     // TODO use devicePersistentFields here
     // TODO this will need a ->get_data() method
@@ -94,25 +100,37 @@ public:
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
           global_values_index_{nElems_ - nInterfaces_},
+          global_interface_index_{nInterfaces_},
           verbose_(solverControls.lookupOrDefault<label>("verbose", 0)),
           ldu_csr_idx_mapping_{
-              fieldName + "ldu_csr_map", db,       exec_,
-              global_values_index_,      verbose_, false,
+              fieldName + "_ldu_csr_map", db,       exec_,
+              global_values_index_,       verbose_, false,
+          },
+          ldu_csr_idx_interface_mapping_{
+              fieldName + "_ldu_csr_interface_map",
+              db,
+              exec_,
+              global_interface_index_,
+              verbose_,
+              false,
           },
           values_{fieldName + "_values", db,       exec_,
-                  global_matrix_index_, verbose_, false},
-          col_idxs_{fieldName + "_cols",   db,       exec_,
+                  global_matrix_index_,  verbose_, false},
+          col_idxs_{fieldName + "_cols",  db,       exec_,
                     global_matrix_index_, verbose_, false},
-          row_idxs_{fieldName + "_rows",   db,       exec_,
+          row_idxs_{fieldName + "_rows",  db,       exec_,
                     global_matrix_index_, verbose_, false}
     {
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
-            SIMPLE_TIME(true, init_host_sparsity_pattern,
-                        init_host_sparsity_pattern(interfaces);)
+            auto other_proc_cell_ids = get_other_proc_cell_ids(interfaces);
+            SIMPLE_TIME(
+                true, init_host_sparsity_pattern,
+                init_host_sparsity_pattern(interfaces, other_proc_cell_ids);)
         }
         if (!values_.get_stored() || values_.get_update()) {
-            SIMPLE_TIME(true, update_host_matrix_data,
-                        update_host_matrix_data(interfaces);)
+            SIMPLE_TIME(
+                true, update_host_matrix_data,
+                update_host_matrix_data(interfaces, interfaceIntCoeffs);)
         }
     }
 
@@ -127,9 +145,18 @@ public:
           nElems_(nCells_ + 2 * nNeighbours_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
+          global_interface_index_{nInterfaces_},
           verbose_(solverControls.lookupOrDefault<label>("verbose", 0)),
           ldu_csr_idx_mapping_{fieldName + "ldu_csr_map", db,       exec_,
                                global_matrix_index_,      verbose_, false},
+          ldu_csr_idx_interface_mapping_{
+              fieldName + "_ldu_csr_interface_map",
+              db,
+              exec_,
+              global_interface_index_,
+              verbose_,
+              false,
+          },
           values_{fieldName + "values", db,       exec_,
                   global_matrix_index_, verbose_, false},
           col_idxs_{fieldName + "cols",   db,       exec_,
@@ -162,15 +189,76 @@ public:
         return ctr;
     }
 
-    void insert_interface_coeffs(const lduInterfaceFieldPtrsList &interfaces,
-                                 int *rows, int *cols, label row,
-                                 label &element_ctr, const bool upper) const
+    std::vector<std::vector<label>> get_other_proc_cell_ids(
+        const lduInterfaceFieldPtrsList &interfaces)
     {
+        std::vector<std::vector<label>> ret{};
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                ret.push_back({});
+                continue;
+            }
+
+            const auto iface{interfaces.operator()(i)};
+
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+
+                word msg = "send face cells interface " + std::to_string(i) +
+                           " from proc " + std::to_string(Pstream::myProcNo()) +
+                           " to neighbour proc " +
+                           std::to_string(pldui.neighbProcNo());
+
+                LOG_2(verbose_, msg)
+                pldui.send(Pstream::commsTypes::blocking,
+                           iface->interface().faceCells());
+                LOG_2(verbose_, "send face cells done")
+
+
+                word msg_2 = "receive face cells interface " +
+                             std::to_string(i) + " from proc " +
+                             std::to_string(pldui.neighbProcNo());
+
+                LOG_2(verbose_, msg_2)
+
+                const label patch_size = iface->interface().faceCells().size();
+
+                auto otherSide_tmp = pldui.receive<label>(
+                    Pstream::commsTypes::blocking, patch_size);
+                LOG_2(verbose_, "receive face cells done")
+
+                std::vector<label> orig_cell_ids{};
+                orig_cell_ids.reserve(patch_size);
+
+                for (label cellI = 0; cellI < patch_size; cellI++) {
+                    orig_cell_ids.push_back(otherSide_tmp()[cellI]);
+                }
+                ret.push_back(orig_cell_ids);
+            }
+        }
+        word msg = "done collecting neighbouring processor cell id";
+
+        LOG_2(verbose_, msg)
+        return ret;
+    }
+
+    // TODO this is pretty much the same as get_other_proc_cell_ids
+    // and could probably trimmed down a lot
+    void insert_interface_coeffs(
+        const lduInterfaceFieldPtrsList &interfaces,
+        const std::vector<std::vector<label>> &other_proc_cell_ids, int *rows,
+        int *cols, label row, label &element_ctr, const bool upper) const
+    {
+        label interface_ctr = 0;
+        auto sorting_interface_idxs = ldu_csr_idx_interface_mapping_.get_data();
         for (int i = 0; i < interfaces.size(); i++) {
             if (interfaces.operator()(i) == nullptr) {
                 continue;
             }
+
             const auto iface{interfaces.operator()(i)};
+            const label interface_size = iface->interface().faceCells().size();
 
             if (isA<processorLduInterface>(iface->interface())) {
                 const processorLduInterface &pldui =
@@ -180,48 +268,43 @@ public:
                 // then own processor idx are not on lower matrix row
                 if (upper) {
                     if (pldui.neighbProcNo() > Pstream::myProcNo()) {
+                        interface_ctr += interface_size;
                         continue;
                     }
+
                 } else {
                     if (pldui.neighbProcNo() < Pstream::myProcNo()) {
+                        interface_ctr += interface_size;
                         continue;
                     }
                 }
 
-		std::cout << "!!!!!!! send \n" ;
-                pldui.send(Pstream::commsTypes::blocking,
-                           iface->interface().faceCells());
-		std::cout << "!!!!!!! send done \n" ;
-
-                auto otherSide_tmp =
-                    pldui.receive<label>(Pstream::commsTypes::blocking,
-                                         iface->interface().faceCells().size());
-		std::cout << "!!!!!!! receive done \n" ;
-
-
-
                 // check if current cell is on the current patch
                 // NOTE cells can be several times on same patch
-                for (label cellI = 0;
-                     cellI < iface->interface().faceCells().size(); cellI++) {
-                    label other_side_cellID = otherSide_tmp()[cellI];
-		const label other_side_global_cellID = global_cell_index_.toGlobal(
-                            pldui.neighbProcNo(), other_side_cellID);
-		    //std::cout << " other_side_cellID " << other_side_cellID 
-	//		    <<  " other_side_global_cellID " <<  other_side_global_cellID << "\n";
+                for (label cellI = 0; cellI < interface_size; cellI++) {
+                    const label other_side_global_cellID =
+                        global_cell_index_.toGlobal(
+                            pldui.neighbProcNo(),
+                            other_proc_cell_ids[i][cellI]);
 
                     if (iface->interface().faceCells()[cellI] == row) {
                         rows[element_ctr] = global_cell_index_.toGlobal(row);
                         cols[element_ctr] = other_side_global_cellID;
+
+                        sorting_interface_idxs[interface_ctr + cellI] =
+                            element_ctr;
+
                         element_ctr++;
                     }
                 }
             }
+            interface_ctr += interface_size;
         }
     }
 
     void init_host_sparsity_pattern(
-        const lduInterfaceFieldPtrsList &interfaces) const
+        const lduInterfaceFieldPtrsList &interfaces,
+        const std::vector<std::vector<label>> other_proc_cell_ids) const
     {
         // Step 1 local ldu -> csr conversion
         // including local processor offset
@@ -255,8 +338,8 @@ public:
 
         for (label row = 0; row < nCells_; row++) {
             // check for lower idxs
-            insert_interface_coeffs(interfaces, rows, cols, row, element_ctr,
-                                    true);
+            insert_interface_coeffs(interfaces, other_proc_cell_ids, rows, cols,
+                                    row, element_ctr, false);
 
             // add lower elements
             // for now just scan till current upper ctr
@@ -303,15 +386,18 @@ public:
                 element_ctr++;
                 upper_ctr++;
             }
-            insert_interface_coeffs(interfaces, rows, cols, row, element_ctr,
-                                    false);
+
+            insert_interface_coeffs(interfaces, other_proc_cell_ids, rows, cols,
+                                    row, element_ctr, true);
         }
+        LOG_1(verbose_, "done init host matrix")
     }
 
     bool get_verbose() const { return verbose_; }
 
     void update_host_matrix_data(
-        const lduInterfaceFieldPtrsList &interfaces) const
+        const lduInterfaceFieldPtrsList &interfaces,
+        const FieldField<Field, scalar> &interfaceIntCoeffs) const
     {
         auto ref_exec = gko::ReferenceExecutor::create();
         // TODO create in ctr
@@ -320,6 +406,9 @@ public:
         auto values = values_.get_data();
 
         const auto sorting_idxs = ldu_csr_idx_mapping_.get_const_data();
+        const auto sorting_interface_idxs =
+            ldu_csr_idx_interface_mapping_.get_const_data();
+
         auto lower = this->matrix().lower();
         auto upper = this->matrix().upper();
         for (label i = 0; i < nNeighbours(); i++) {
@@ -331,7 +420,22 @@ public:
         for (label i = 0; i < local_nCells(); ++i) {
             values[sorting_idxs[i + 2 * nNeighbours_]] = diag[i];
         }
-    };
+
+        label interface_ctr{0};
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                continue;
+            }
+            const label patch_size =
+                interfaces.operator()(i)->interface().faceCells().size();
+
+            for (label cellI = 0; cellI < patch_size; cellI++) {
+                values[sorting_interface_idxs[interface_ctr]] =
+                    interfaceIntCoeffs[i][cellI];
+                interface_ctr++;
+            }
+        }
+    }
 
     label local_nCells() const { return nCells_; }
 

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -248,17 +248,18 @@ public:
     void insert_interface_coeffs(
         const lduInterfaceFieldPtrsList &interfaces,
         const std::vector<std::vector<label>> &other_proc_cell_ids, int *rows,
-        int *cols, label row, label &element_ctr, const bool upper) const
+        int *cols, label row, label &element_ctr, label *sorting_interface_idxs,
+        const bool upper) const
     {
         label interface_ctr = 0;
-        auto sorting_interface_idxs = ldu_csr_idx_interface_mapping_.get_data();
         for (int i = 0; i < interfaces.size(); i++) {
             if (interfaces.operator()(i) == nullptr) {
                 continue;
             }
 
             const auto iface{interfaces.operator()(i)};
-            const label interface_size = iface->interface().faceCells().size();
+            const auto face_cells{iface->interface().faceCells()};
+            const label interface_size = face_cells.size();
 
             if (isA<processorLduInterface>(iface->interface())) {
                 const processorLduInterface &pldui =
@@ -287,7 +288,7 @@ public:
                             pldui.neighbProcNo(),
                             other_proc_cell_ids[i][cellI]);
 
-                    if (iface->interface().faceCells()[cellI] == row) {
+                    if (face_cells[cellI] == row) {
                         rows[element_ctr] = global_cell_index_.toGlobal(row);
                         cols[element_ctr] = other_side_global_cellID;
 
@@ -308,16 +309,14 @@ public:
     {
         // Step 1 local ldu -> csr conversion
         // including local processor offset
-
-        auto ref_exec = gko::ReferenceExecutor::create();
-
+        LOG_1(verbose_, "start init host sparsity pattern")
 
         auto lower_local = idx_array::view(
-            ref_exec, nNeighbours_,
+            exec_.get_ref_exec(), nNeighbours_,
             const_cast<label *>(&this->matrix().lduAddr().lowerAddr()[0]));
 
         auto upper_local = idx_array::view(
-            ref_exec, nNeighbours_,
+            exec_.get_ref_exec(), nNeighbours_,
             const_cast<label *>(&this->matrix().lduAddr().upperAddr()[0]));
 
         const auto lower = lower_local.get_const_data();
@@ -335,11 +334,13 @@ public:
 
 
         const auto sorting_idxs = ldu_csr_idx_mapping_.get_data();
+        auto sorting_interface_idxs = ldu_csr_idx_interface_mapping_.get_data();
 
         for (label row = 0; row < nCells_; row++) {
             // check for lower idxs
             insert_interface_coeffs(interfaces, other_proc_cell_ids, rows, cols,
-                                    row, element_ctr, false);
+                                    row, element_ctr, sorting_interface_idxs,
+                                    false);
 
             // add lower elements
             // for now just scan till current upper ctr
@@ -388,7 +389,8 @@ public:
             }
 
             insert_interface_coeffs(interfaces, other_proc_cell_ids, rows, cols,
-                                    row, element_ctr, true);
+                                    row, element_ctr, sorting_interface_idxs,
+                                    true);
         }
         LOG_1(verbose_, "done init host matrix")
     }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -162,6 +162,46 @@ public:
         return ctr;
     }
 
+    void insert_interface_coeffs(const lduInterfaceFieldPtrsList &interfaces,
+                                 scalar *rows, scalar *cols, label &element_ctr,
+                                 const bool upper) const
+    {
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                continue;
+            }
+            const auto iface{interfaces.operator()(i)};
+
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+
+                // if rank of corresponding processor is greater
+                // then own processor idx are not on lower matrix row
+                if (upper) {
+                    if (pldui.neighbProcNo() > Pstream::myProcNo()) {
+                        continue;
+                    }
+                } else {
+                    if (pldui.neighbProcNo() < Pstream::myProcNo()) {
+                        continue;
+                    }
+                }
+
+                // check if current cell is on the current patch
+                // NOTE cells can be several times on same patch
+                for (int cellI = 0;
+                     cellI < iface->interface().faceCells().size(); cellI++) {
+                    if (iface->interface().faceCells()[cellI] == row) {
+                        rows[element_ctr] = global_cell_index_.toGlobal(row);
+                        cols[element_ctr] = 66;
+                        element_ctr++;
+                    }
+                }
+            }
+        }
+    }
+
     void init_host_sparsity_pattern(
         const lduInterfaceFieldPtrsList &interfaces) const
     {
@@ -200,37 +240,7 @@ public:
 
         for (label row = 0; row < nCells_; row++) {
             // check for lower idxs
-            for (int i = 0; i < interfaces.size(); i++) {
-                if (interfaces.operator()(i) == nullptr) {
-                    continue;
-                }
-                const auto iface{interfaces.operator()(i)};
-
-                if (isA<processorLduInterface>(iface->interface())) {
-                    const processorLduInterface &pldui =
-                        refCast<const processorLduInterface>(
-                            iface->interface());
-
-                    // if rank of corresponding processor is greater
-                    // then own processor idx are not on lower matrix row
-                    if (pldui.neighbProcNo() > Pstream::myProcNo()) {
-                        continue;
-                    }
-
-                    // check if current cell is on the current patch
-                    // NOTE cells can be several times on same patch
-                    for (int cellI = 0;
-                         cellI < iface->interface().faceCells().size();
-                         cellI++) {
-                        if (iface->interface().faceCells()[cellI] == row) {
-                            rows[element_ctr] =
-                                global_cell_index_.toGlobal(row);
-                            cols[element_ctr] = 66;
-                            element_ctr++;
-                        }
-                    }
-                }
-            }
+            insert_interface_coeffs(interfaces, rows, cols, element_ctr, true);
 
             // add lower elements
             // for now just scan till current upper ctr
@@ -277,42 +287,8 @@ public:
                 element_ctr++;
                 upper_ctr++;
             }
-
-            // check for upper idxs
-            for (int i = 0; i < interfaces.size(); i++) {
-                if (interfaces.operator()(i) == nullptr) {
-                    continue;
-                }
-                const auto iface{interfaces.operator()(i)};
-
-                if (isA<processorLduInterface>(iface->interface())) {
-                    const processorLduInterface &pldui =
-                        refCast<const processorLduInterface>(
-                            iface->interface());
-
-                    // if rank of corresponding processor is smaller
-                    // then own processor idx are not on upper matrix row
-                    if (pldui.neighbProcNo() < Pstream::myProcNo()) {
-                        continue;
-                    }
-
-                    // check if current cell is on the current patch
-                    for (label cellI = 0;
-                         cellI < iface->interface().faceCells().size();
-                         cellI++) {
-                        if (iface->interface().faceCells()[cellI] == row) {
-                            rows[element_ctr] =
-                                global_cell_index_.toGlobal(row);
-                            cols[element_ctr] = 66;
-                            element_ctr++;
-                        }
-                    }
-                }
-            }
+            insert_interface_coeffs(interfaces, rows, cols, element_ctr, false);
         }
-        std::cout << "!!!!!!! final element " << element_ctr << " nElems "
-                  << nElems_ << "\n";
-        // TODO test if elements are unfilled
     }
 
     bool get_verbose() const { return verbose_; }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -122,7 +122,8 @@ public:
                     global_matrix_index_, verbose_, false}
     {
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
-            auto other_proc_cell_ids = get_other_proc_cell_ids(interfaces);
+            auto other_proc_cell_ids =
+                get_other_proc_cell_ids(nInterfaces_, interfaces);
             SIMPLE_TIME(
                 verbose_, init_host_sparsity_pattern,
                 init_host_sparsity_pattern(interfaces, other_proc_cell_ids);)
@@ -189,52 +190,46 @@ public:
         return ctr;
     }
 
-    std::vector<std::vector<label>> get_other_proc_cell_ids(
-        const lduInterfaceFieldPtrsList &interfaces)
+    std::vector<label> get_other_proc_cell_ids(
+        const label nInterfaces, const lduInterfaceFieldPtrsList &interfaces)
     {
-        std::vector<std::vector<label>> ret{};
+        std::vector<label> ret{};
+        ret.reserve(nInterfaces);
+
         for (int i = 0; i < interfaces.size(); i++) {
             if (interfaces.operator()(i) == nullptr) {
-                ret.push_back({});
                 continue;
             }
 
             const auto iface{interfaces.operator()(i)};
+            const auto &face_cells{iface->interface().faceCells()};
+            const label interface_size = face_cells.size();
 
             if (isA<processorLduInterface>(iface->interface())) {
                 const processorLduInterface &pldui =
                     refCast<const processorLduInterface>(iface->interface());
+                const label neighbProcNo = pldui.neighbProcNo();
 
                 word msg = "send face cells interface " + std::to_string(i) +
                            " from proc " + std::to_string(Pstream::myProcNo()) +
-                           " to neighbour proc " +
-                           std::to_string(pldui.neighbProcNo());
+                           " to neighbour proc " + std::to_string(neighbProcNo);
 
                 LOG_2(verbose_, msg)
-                pldui.send(Pstream::commsTypes::blocking,
-                           iface->interface().faceCells());
+                pldui.send(Pstream::commsTypes::blocking, face_cells);
                 LOG_2(verbose_, "send face cells done")
-
 
                 word msg_2 = "receive face cells interface " +
                              std::to_string(i) + " from proc " +
-                             std::to_string(pldui.neighbProcNo());
-
+                             std::to_string(neighbProcNo);
                 LOG_2(verbose_, msg_2)
 
-                const label patch_size = iface->interface().faceCells().size();
-
                 auto otherSide_tmp = pldui.receive<label>(
-                    Pstream::commsTypes::blocking, patch_size);
+                    Pstream::commsTypes::blocking, interface_size);
                 LOG_2(verbose_, "receive face cells done")
 
-                std::vector<label> orig_cell_ids{};
-                orig_cell_ids.reserve(patch_size);
-
-                for (label cellI = 0; cellI < patch_size; cellI++) {
-                    orig_cell_ids.push_back(otherSide_tmp()[cellI]);
+                for (label cellI = 0; cellI < interface_size; cellI++) {
+                    ret.push_back(otherSide_tmp()[cellI]);
                 }
-                ret.push_back(orig_cell_ids);
             }
         }
         word msg = "done collecting neighbouring processor cell id";
@@ -245,11 +240,12 @@ public:
 
     // TODO this is pretty much the same as get_other_proc_cell_ids
     // and could probably trimmed down a lot
-    void insert_interface_coeffs(
-        const lduInterfaceFieldPtrsList &interfaces,
-        const std::vector<std::vector<label>> &other_proc_cell_ids, int *rows,
-        int *cols, label row, label &element_ctr, label *sorting_interface_idxs,
-        const bool upper) const
+    void insert_interface_coeffs(const lduInterfaceFieldPtrsList &interfaces,
+                                 const std::vector<label> &other_proc_cell_ids,
+                                 int *rows, int *cols, label row,
+                                 label &element_ctr,
+                                 label *sorting_interface_idxs,
+                                 const bool upper) const
     {
         label interface_ctr = 0;
         for (int i = 0; i < interfaces.size(); i++) {
@@ -257,8 +253,8 @@ public:
                 continue;
             }
 
-            const auto iface{interfaces.operator()(i)};
-            const auto face_cells{iface->interface().faceCells()};
+            const auto &iface{interfaces.operator()(i)};
+            const auto &face_cells{iface->interface().faceCells()};
             const label interface_size = face_cells.size();
 
             if (isA<processorLduInterface>(iface->interface())) {
@@ -267,14 +263,15 @@ public:
 
                 // if rank of corresponding processor is greater
                 // then own processor idx are not on lower matrix row
+                const label neighbProcNo = pldui.neighbProcNo();
                 if (upper) {
-                    if (pldui.neighbProcNo() > Pstream::myProcNo()) {
+                    if (neighbProcNo > Pstream::myProcNo()) {
                         interface_ctr += interface_size;
                         continue;
                     }
 
                 } else {
-                    if (pldui.neighbProcNo() < Pstream::myProcNo()) {
+                    if (neighbProcNo < Pstream::myProcNo()) {
                         interface_ctr += interface_size;
                         continue;
                     }
@@ -283,12 +280,20 @@ public:
                 // check if current cell is on the current patch
                 // NOTE cells can be several times on same patch
                 for (label cellI = 0; cellI < interface_size; cellI++) {
-                    const label other_side_global_cellID =
-                        global_cell_index_.toGlobal(
-                            pldui.neighbProcNo(),
-                            other_proc_cell_ids[i][cellI]);
-
                     if (face_cells[cellI] == row) {
+                        const label other_side_global_cellID =
+                            global_cell_index_.toGlobal(
+                                neighbProcNo,
+                                other_proc_cell_ids[interface_ctr + cellI]);
+                        std::cout << " Pstream::myProcNo() "
+                                  << Pstream::myProcNo() << " row " << row
+                                  << " face_cells[cellI]" << face_cells[cellI]
+                                  << " other_proc_cell_ids[interface_ctr + "
+                                     "cellI] "
+                                  << other_proc_cell_ids[interface_ctr + cellI]
+                                  << " other_side_global_cellID "
+                                  << other_side_global_cellID << std::endl;
+
                         rows[element_ctr] = global_cell_index_.toGlobal(row);
                         cols[element_ctr] = other_side_global_cellID;
 
@@ -305,7 +310,7 @@ public:
 
     void init_host_sparsity_pattern(
         const lduInterfaceFieldPtrsList &interfaces,
-        const std::vector<std::vector<label>> other_proc_cell_ids) const
+        const std::vector<label> other_proc_cell_ids) const
     {
         // Step 1 local ldu -> csr conversion
         // including local processor offset

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -129,9 +129,11 @@ public:
                 init_host_sparsity_pattern(interfaces, other_proc_cell_ids);)
         }
         if (!values_.get_stored() || values_.get_update()) {
+            auto other_proc_bou_coeffs = get_other_proc_bou_coeffs(
+                nInterfaces_, interfaces, interfaceBouCoeffs);
             SIMPLE_TIME(
                 verbose_, update_host_matrix_data,
-                update_host_matrix_data(interfaces, interfaceBouCoeffs);)
+                update_host_matrix_data(interfaces, other_proc_bou_coeffs);)
         }
     }
 
@@ -188,6 +190,74 @@ public:
             ctr += iface->interface().faceCells().size();
         }
         return ctr;
+    }
+
+    // TODO merge with get_other_proc_cell_ids
+    std::vector<scalar> get_other_proc_bou_coeffs(
+        const label nInterfaces, const lduInterfaceFieldPtrsList &interfaces,
+        const FieldField<Field, scalar> interfaceBouCoeffs)
+    {
+        std::vector<scalar> ret{};
+        ret.reserve(nInterfaces);
+
+        label startOfRequests = Pstream::nRequests();
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                continue;
+            }
+
+            const auto iface{interfaces.operator()(i)};
+            const auto &face_cells{interfaceBouCoeffs[i]};
+            const label interface_size = face_cells.size();
+
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+                const label neighbProcNo = pldui.neighbProcNo();
+
+                word msg = "send face cells interface " + std::to_string(i) +
+                           " from proc " + std::to_string(Pstream::myProcNo()) +
+                           " to neighbour proc " + std::to_string(neighbProcNo);
+
+                LOG_2(verbose_, msg)
+                pldui.send(Pstream::commsTypes::nonBlocking, face_cells);
+            }
+        }
+        Pstream::waitRequests(startOfRequests);
+        LOG_2(verbose_, "send face cells done")
+
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                continue;
+            }
+
+            const auto iface{interfaces.operator()(i)};
+            const auto &face_cells{iface->interface().faceCells()};
+            const label interface_size = face_cells.size();
+
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+                const label neighbProcNo = pldui.neighbProcNo();
+
+                word msg_2 = "receive face cells interface " +
+                             std::to_string(i) + " from proc " +
+                             std::to_string(neighbProcNo);
+                LOG_2(verbose_, msg_2)
+
+                auto otherSide_tmp = pldui.receive<label>(
+                    Pstream::commsTypes::nonBlocking, interface_size);
+                LOG_2(verbose_, "receive face cells done")
+
+                for (label cellI = 0; cellI < interface_size; cellI++) {
+                    ret.push_back(otherSide_tmp()[cellI]);
+                }
+            }
+        }
+        word msg = "done collecting neighbouring processor cell id";
+
+        LOG_2(verbose_, msg)
+        return ret;
     }
 
     std::vector<label> get_other_proc_cell_ids(
@@ -422,7 +492,7 @@ public:
 
     void update_host_matrix_data(
         const lduInterfaceFieldPtrsList &interfaces,
-        const FieldField<Field, scalar> &interfaceBouCoeffs) const
+        const std::vector<scalar> &interfaceBouCoeffs) const
     {
         auto ref_exec = gko::ReferenceExecutor::create();
         // TODO create in ctr
@@ -459,9 +529,8 @@ public:
             }
 
             for (label cellI = 0; cellI < patch_size; cellI++) {
-                // FIXME use interfaceIntCoeffs from other proccessor
                 values[sorting_interface_idxs[interface_ctr]] =
-                    -interfaceBouCoeffs[i][cellI];
+                    -interfaceBouCoeffs[interface_ctr];
                 interface_ctr++;
             }
         }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -32,6 +32,7 @@ SourceFiles
 #include "../DevicePersistentArray/DevicePersistentArray.H"
 #include "../IOGlobalIndex/gkoGlobalIndex.H"
 
+
 namespace Foam {
 
 template <class MatrixType>
@@ -44,6 +45,8 @@ private:
     const label nCells_;
 
     const label nNeighbours_;
+
+    const label nInterfaces_;
 
     const label nElems_;
 
@@ -82,6 +85,9 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
+	  nInterfaces_(
+                       count_elements_on_interfaces(interfaces)
+			  ),
           nElems_(nCells_ + 2 * nNeighbours_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
@@ -97,6 +103,7 @@ public:
           row_idxs_{fieldName + "rows",   db,       exec_,
                     global_matrix_index_, verbose_, false}
     {
+	std::cout << "!!!!! DEBUG nElems_ + interface " << nElems_ + nInterfaces_ << "\n";
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
             SIMPLE_TIME(true, init_host_sparsity_pattern,
                         init_host_sparsity_pattern();)
@@ -114,6 +121,7 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
+	  nInterfaces_(0),
           nElems_(nCells_ + 2 * nNeighbours_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
@@ -136,6 +144,19 @@ public:
             SIMPLE_TIME(true, update_host_matrix_data,
                         update_host_matrix_data();)
         }
+    }
+
+    label count_elements_on_interfaces(
+        const lduInterfaceFieldPtrsList &ifaces) const
+    {
+        label ctr{0};
+        for (int i = 0; i<ifaces.size(); i++) {
+            if (ifaces.operator()(i) == nullptr) {
+                continue;
+            }
+            ctr +=  ifaces.operator()(i)->interface().faceCells().size();
+        }
+        return ctr;
     }
 
     void init_host_sparsity_pattern() const

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -89,7 +89,7 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
-          nInterfaces_(count_elements_on_interfaces(interfaces) ),
+          nInterfaces_(count_elements_on_interfaces(interfaces)),
           nElems_(nCells_ + 2 * nNeighbours_ + nInterfaces_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
@@ -199,7 +199,6 @@ public:
         const auto sorting_idxs = ldu_csr_idx_mapping_.get_data();
 
         for (label row = 0; row < nCells_; row++) {
-
             // check for lower idxs
             for (int i = 0; i < interfaces.size(); i++) {
                 if (interfaces.operator()(i) == nullptr) {
@@ -219,18 +218,17 @@ public:
                     }
 
                     // check if current cell is on the current patch
-		    // NOTE cells can be several times on same patch
-			for (int cellI = 0;
-			     cellI < iface->interface().faceCells().size();
-			     cellI++) {
-			    if (iface->interface().faceCells()[cellI] == row) {
-				rows[element_ctr] = global_cell_index_.toGlobal(row);
-				cols[element_ctr] = 66;
-				element_ctr++;
-			    }
-			}
-
-
+                    // NOTE cells can be several times on same patch
+                    for (int cellI = 0;
+                         cellI < iface->interface().faceCells().size();
+                         cellI++) {
+                        if (iface->interface().faceCells()[cellI] == row) {
+                            rows[element_ctr] =
+                                global_cell_index_.toGlobal(row);
+                            cols[element_ctr] = 66;
+                            element_ctr++;
+                        }
+                    }
                 }
             }
 
@@ -299,22 +297,22 @@ public:
                     }
 
                     // check if current cell is on the current patch
-			for (label cellI = 0;
-			     cellI < iface->interface().faceCells().size();
-			     cellI++) {
-			    if (iface->interface().faceCells()[cellI] == row) {
-				rows[element_ctr] = global_cell_index_.toGlobal(row);
-				cols[element_ctr] = 66;
-				element_ctr++;
-			    }
-			}
-
-
+                    for (label cellI = 0;
+                         cellI < iface->interface().faceCells().size();
+                         cellI++) {
+                        if (iface->interface().faceCells()[cellI] == row) {
+                            rows[element_ctr] =
+                                global_cell_index_.toGlobal(row);
+                            cols[element_ctr] = 66;
+                            element_ctr++;
+                        }
+                    }
                 }
             }
         }
-	std::cout << "!!!!!!! final element " << element_ctr << " nElems " << nElems_ << "\n";
-	// TODO test if elements are unfilled
+        std::cout << "!!!!!!! final element " << element_ctr << " nElems "
+                  << nElems_ << "\n";
+        // TODO test if elements are unfilled
     }
 
     bool get_verbose() const { return verbose_; }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -89,7 +89,7 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
-          nInterfaces_(count_elements_on_interfaces(interfaces) / 2),
+          nInterfaces_(count_elements_on_interfaces(interfaces) ),
           nElems_(nCells_ + 2 * nNeighbours_ + nInterfaces_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
@@ -158,12 +158,6 @@ public:
             }
             const auto iface{interfaces_.operator()(i)};
             ctr += iface->interface().faceCells().size();
-            if (isA<processorLduInterface>(iface->interface())) {
-                const processorLduInterface &pldui =
-                    refCast<const processorLduInterface>(iface->interface());
-                std::cout << "!!!!!! lduInterfaceFieldPtrs "
-                          << pldui.neighbProcNo() << "\n";
-            }
         }
         return ctr;
     }
@@ -205,6 +199,7 @@ public:
         const auto sorting_idxs = ldu_csr_idx_mapping_.get_data();
 
         for (label row = 0; row < nCells_; row++) {
+
             // check for lower idxs
             for (int i = 0; i < interfaces.size(); i++) {
                 if (interfaces.operator()(i) == nullptr) {
@@ -224,22 +219,18 @@ public:
                     }
 
                     // check if current cell is on the current patch
-                    bool isOnPatch{false};
-                    for (label cellI = 0;
-                         cellI < iface->interface().faceCells().size();
-                         cellI++) {
-                        if (iface->interface().faceCells()[cellI] == row) {
-                            isOnPatch = true;
-                        }
-                    }
+		    // NOTE cells can be several times on same patch
+			for (int cellI = 0;
+			     cellI < iface->interface().faceCells().size();
+			     cellI++) {
+			    if (iface->interface().faceCells()[cellI] == row) {
+				rows[element_ctr] = global_cell_index_.toGlobal(row);
+				cols[element_ctr] = 66;
+				element_ctr++;
+			    }
+			}
 
-                    // leave a marker
-                    if (isOnPatch) {
-                        rows[element_ctr] = 0;
-                        cols[element_ctr] = 0;
-                    }
 
-                    element_ctr++;
                 }
             }
 
@@ -288,7 +279,42 @@ public:
                 element_ctr++;
                 upper_ctr++;
             }
+
+            // check for upper idxs
+            for (int i = 0; i < interfaces.size(); i++) {
+                if (interfaces.operator()(i) == nullptr) {
+                    continue;
+                }
+                const auto iface{interfaces.operator()(i)};
+
+                if (isA<processorLduInterface>(iface->interface())) {
+                    const processorLduInterface &pldui =
+                        refCast<const processorLduInterface>(
+                            iface->interface());
+
+                    // if rank of corresponding processor is smaller
+                    // then own processor idx are not on upper matrix row
+                    if (pldui.neighbProcNo() < Pstream::myProcNo()) {
+                        continue;
+                    }
+
+                    // check if current cell is on the current patch
+			for (label cellI = 0;
+			     cellI < iface->interface().faceCells().size();
+			     cellI++) {
+			    if (iface->interface().faceCells()[cellI] == row) {
+				rows[element_ctr] = global_cell_index_.toGlobal(row);
+				cols[element_ctr] = 66;
+				element_ctr++;
+			    }
+			}
+
+
+                }
+            }
         }
+	std::cout << "!!!!!!! final element " << element_ctr << " nElems " << nElems_ << "\n";
+	// TODO test if elements are unfilled
     }
 
     bool get_verbose() const { return verbose_; }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -196,6 +196,7 @@ public:
         std::vector<label> ret{};
         ret.reserve(nInterfaces);
 
+        label startOfRequests = Pstream::nRequests();
         for (int i = 0; i < interfaces.size(); i++) {
             if (interfaces.operator()(i) == nullptr) {
                 continue;
@@ -215,8 +216,25 @@ public:
                            " to neighbour proc " + std::to_string(neighbProcNo);
 
                 LOG_2(verbose_, msg)
-                pldui.send(Pstream::commsTypes::blocking, face_cells);
-                LOG_2(verbose_, "send face cells done")
+                pldui.send(Pstream::commsTypes::nonBlocking, face_cells);
+            }
+        }
+        Pstream::waitRequests(startOfRequests);
+        LOG_2(verbose_, "send face cells done")
+
+        for (int i = 0; i < interfaces.size(); i++) {
+            if (interfaces.operator()(i) == nullptr) {
+                continue;
+            }
+
+            const auto iface{interfaces.operator()(i)};
+            const auto &face_cells{iface->interface().faceCells()};
+            const label interface_size = face_cells.size();
+
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+                const label neighbProcNo = pldui.neighbProcNo();
 
                 word msg_2 = "receive face cells interface " +
                              std::to_string(i) + " from proc " +
@@ -224,7 +242,7 @@ public:
                 LOG_2(verbose_, msg_2)
 
                 auto otherSide_tmp = pldui.receive<label>(
-                    Pstream::commsTypes::blocking, interface_size);
+                    Pstream::commsTypes::nonBlocking, interface_size);
                 LOG_2(verbose_, "receive face cells done")
 
                 for (label cellI = 0; cellI < interface_size; cellI++) {

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -430,6 +430,7 @@ public:
                 interfaces.operator()(i)->interface().faceCells().size();
 
             for (label cellI = 0; cellI < patch_size; cellI++) {
+                // FIXME use interfaceIntCoeffs from other proccessor
                 values[sorting_interface_idxs[interface_ctr]] =
                     interfaceIntCoeffs[i][cellI];
                 interface_ctr++;

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -99,11 +99,11 @@ public:
               fieldName + "ldu_csr_map", db,       exec_,
               global_values_index_,      verbose_, false,
           },
-          values_{fieldName + "values", db,       exec_,
+          values_{fieldName + "_values", db,       exec_,
                   global_matrix_index_, verbose_, false},
-          col_idxs_{fieldName + "cols",   db,       exec_,
+          col_idxs_{fieldName + "_cols",   db,       exec_,
                     global_matrix_index_, verbose_, false},
-          row_idxs_{fieldName + "rows",   db,       exec_,
+          row_idxs_{fieldName + "_rows",   db,       exec_,
                     global_matrix_index_, verbose_, false}
     {
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
@@ -188,12 +188,16 @@ public:
                     }
                 }
 
-                pldui.send(Pstream::commsTypes::nonBlocking,
+		std::cout << "!!!!!!! send \n" ;
+                pldui.send(Pstream::commsTypes::blocking,
                            iface->interface().faceCells());
+		std::cout << "!!!!!!! send done \n" ;
 
                 auto otherSide_tmp =
-                    pldui.receive<label>(Pstream::commsTypes::nonBlocking,
+                    pldui.receive<label>(Pstream::commsTypes::blocking,
                                          iface->interface().faceCells().size());
+		std::cout << "!!!!!!! receive done \n" ;
+
 
 
                 // check if current cell is on the current patch
@@ -201,10 +205,14 @@ public:
                 for (label cellI = 0;
                      cellI < iface->interface().faceCells().size(); cellI++) {
                     label other_side_cellID = otherSide_tmp()[cellI];
+		const label other_side_global_cellID = global_cell_index_.toGlobal(
+                            pldui.neighbProcNo(), other_side_cellID);
+		    //std::cout << " other_side_cellID " << other_side_cellID 
+	//		    <<  " other_side_global_cellID " <<  other_side_global_cellID << "\n";
+
                     if (iface->interface().faceCells()[cellI] == row) {
                         rows[element_ctr] = global_cell_index_.toGlobal(row);
-                        cols[element_ctr] = global_cell_index_.toGlobal(
-                            pldui.neighbProcNo(), other_side_cellID);
+                        cols[element_ctr] = other_side_global_cellID;
                         element_ctr++;
                     }
                 }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -245,7 +245,7 @@ public:
                              std::to_string(neighbProcNo);
                 LOG_2(verbose_, msg_2)
 
-                auto otherSide_tmp = pldui.receive<label>(
+                auto otherSide_tmp = pldui.receive<scalar>(
                     Pstream::commsTypes::nonBlocking, interface_size);
                 LOG_2(verbose_, "receive face cells done")
 
@@ -391,8 +391,8 @@ public:
                         element_ctr++;
                     }
                 }
+                interface_ctr += interface_size;
             }
-            interface_ctr += interface_size;
         }
     }
 
@@ -529,10 +529,10 @@ public:
             }
 
             for (label cellI = 0; cellI < patch_size; cellI++) {
-                values[sorting_interface_idxs[interface_ctr]] =
-                    -interfaceBouCoeffs[interface_ctr];
-                interface_ctr++;
+                values[sorting_interface_idxs[interface_ctr + cellI]] =
+                    -interfaceBouCoeffs[interface_ctr + cellI];
             }
+            interface_ctr += patch_size;
         }
     }
 

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -27,6 +27,7 @@ SourceFiles
 #include <ginkgo/ginkgo.hpp>
 
 #include "fvCFD.H"
+#include "processorLduInterface.H"
 
 #include <vector>
 #include "../DevicePersistentArray/DevicePersistentArray.H"
@@ -154,7 +155,13 @@ public:
             if (ifaces.operator()(i) == nullptr) {
                 continue;
             }
-            ctr +=  ifaces.operator()(i)->interface().faceCells().size();
+	    const auto iface {ifaces.operator()(i)};
+            ctr += iface->interface().faceCells().size();
+	    if (isA<processorLduInterface>(iface->interface())) {
+		    const processorLduInterface &pldui = refCast<
+const processorLduInterface  > (iface->interface());
+		    std::cout << "!!!!!! lduInterfaceFieldPtrs " << pldui.neighbProcNo() << "\n";
+	    }
         }
         return ctr;
     }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -436,7 +436,7 @@ public:
             for (label cellI = 0; cellI < patch_size; cellI++) {
                 // FIXME use interfaceIntCoeffs from other proccessor
                 values[sorting_interface_idxs[interface_ctr]] =
-                    interfaceBouCoeffs[i][cellI];
+                    -interfaceBouCoeffs[i][cellI];
                 interface_ctr++;
             }
         }

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -56,8 +56,11 @@ private:
     // global index of the full matrix sparsity pattern
     const gkoGlobalIndex global_matrix_index_;
 
+    const gkoGlobalIndex global_values_index_;
+
     const label verbose_;
 
+    // TODO
     mutable PersistentArray<label> ldu_csr_idx_mapping_;
 
     // TODO use devicePersistentFields here
@@ -86,16 +89,15 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
-	  nInterfaces_(
-                       count_elements_on_interfaces(interfaces)
-			  ),
-          nElems_(nCells_ + 2 * nNeighbours_),
+          nInterfaces_(count_elements_on_interfaces(interfaces) / 2),
+          nElems_(nCells_ + 2 * nNeighbours_ + nInterfaces_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
+          global_values_index_{nElems_ - nInterfaces_},
           verbose_(solverControls.lookupOrDefault<label>("verbose", 0)),
           ldu_csr_idx_mapping_{
               fieldName + "ldu_csr_map", db,       exec_,
-              global_matrix_index_,      verbose_, false,
+              global_values_index_,      verbose_, false,
           },
           values_{fieldName + "values", db,       exec_,
                   global_matrix_index_, verbose_, false},
@@ -104,14 +106,13 @@ public:
           row_idxs_{fieldName + "rows",   db,       exec_,
                     global_matrix_index_, verbose_, false}
     {
-	std::cout << "!!!!! DEBUG nElems_ + interface " << nElems_ + nInterfaces_ << "\n";
         if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
             SIMPLE_TIME(true, init_host_sparsity_pattern,
-                        init_host_sparsity_pattern();)
+                        init_host_sparsity_pattern(interfaces);)
         }
         if (!values_.get_stored() || values_.get_update()) {
             SIMPLE_TIME(true, update_host_matrix_data,
-                        update_host_matrix_data();)
+                        update_host_matrix_data(interfaces);)
         }
     }
 
@@ -122,7 +123,7 @@ public:
           exec_{db, solverControls, fieldName},
           nCells_(matrix.diag().size()),
           nNeighbours_(matrix.lduAddr().upperAddr().size()),
-	  nInterfaces_(0),
+          nInterfaces_(0),
           nElems_(nCells_ + 2 * nNeighbours_),
           global_cell_index_{nCells_},
           global_matrix_index_{nElems_},
@@ -136,37 +137,39 @@ public:
           row_idxs_{fieldName + "rows",   db,       exec_,
                     global_matrix_index_, verbose_, false}
     {
-        if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
-            SIMPLE_TIME(true, init_host_sparsity_pattern,
-                        init_host_sparsity_pattern();)
-        }
+        // if (!col_idxs_.get_stored() || col_idxs_.get_update()) {
+        //     SIMPLE_TIME(true, init_host_sparsity_pattern,
+        //                 init_host_sparsity_pattern();)
+        // }
 
-        if (!values_.get_stored() || values_.get_update()) {
-            SIMPLE_TIME(true, update_host_matrix_data,
-                        update_host_matrix_data();)
-        }
+        // if (!values_.get_stored() || values_.get_update()) {
+        //     SIMPLE_TIME(true, update_host_matrix_data,
+        //                 update_host_matrix_data();)
+        // }
     }
 
     label count_elements_on_interfaces(
-        const lduInterfaceFieldPtrsList &ifaces) const
+        const lduInterfaceFieldPtrsList &interfaces_) const
     {
         label ctr{0};
-        for (int i = 0; i<ifaces.size(); i++) {
-            if (ifaces.operator()(i) == nullptr) {
+        for (int i = 0; i < interfaces_.size(); i++) {
+            if (interfaces_.operator()(i) == nullptr) {
                 continue;
             }
-	    const auto iface {ifaces.operator()(i)};
+            const auto iface{interfaces_.operator()(i)};
             ctr += iface->interface().faceCells().size();
-	    if (isA<processorLduInterface>(iface->interface())) {
-		    const processorLduInterface &pldui = refCast<
-const processorLduInterface  > (iface->interface());
-		    std::cout << "!!!!!! lduInterfaceFieldPtrs " << pldui.neighbProcNo() << "\n";
-	    }
+            if (isA<processorLduInterface>(iface->interface())) {
+                const processorLduInterface &pldui =
+                    refCast<const processorLduInterface>(iface->interface());
+                std::cout << "!!!!!! lduInterfaceFieldPtrs "
+                          << pldui.neighbProcNo() << "\n";
+            }
         }
         return ctr;
     }
 
-    void init_host_sparsity_pattern() const
+    void init_host_sparsity_pattern(
+        const lduInterfaceFieldPtrsList &interfaces) const
     {
         // Step 1 local ldu -> csr conversion
         // including local processor offset
@@ -202,6 +205,44 @@ const processorLduInterface  > (iface->interface());
         const auto sorting_idxs = ldu_csr_idx_mapping_.get_data();
 
         for (label row = 0; row < nCells_; row++) {
+            // check for lower idxs
+            for (int i = 0; i < interfaces.size(); i++) {
+                if (interfaces.operator()(i) == nullptr) {
+                    continue;
+                }
+                const auto iface{interfaces.operator()(i)};
+
+                if (isA<processorLduInterface>(iface->interface())) {
+                    const processorLduInterface &pldui =
+                        refCast<const processorLduInterface>(
+                            iface->interface());
+
+                    // if rank of corresponding processor is greater
+                    // then own processor idx are not on lower matrix row
+                    if (pldui.neighbProcNo() > Pstream::myProcNo()) {
+                        continue;
+                    }
+
+                    // check if current cell is on the current patch
+                    bool isOnPatch{false};
+                    for (label cellI = 0;
+                         cellI < iface->interface().faceCells().size();
+                         cellI++) {
+                        if (iface->interface().faceCells()[cellI] == row) {
+                            isOnPatch = true;
+                        }
+                    }
+
+                    // leave a marker
+                    if (isOnPatch) {
+                        rows[element_ctr] = 0;
+                        cols[element_ctr] = 0;
+                    }
+
+                    element_ctr++;
+                }
+            }
+
             // add lower elements
             // for now just scan till current upper ctr
             if (!lower_stack[row].empty()) {
@@ -252,7 +293,8 @@ const processorLduInterface  > (iface->interface());
 
     bool get_verbose() const { return verbose_; }
 
-    void update_host_matrix_data() const
+    void update_host_matrix_data(
+        const lduInterfaceFieldPtrsList &interfaces) const
     {
         auto ref_exec = gko::ReferenceExecutor::create();
         // TODO create in ctr

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -163,8 +163,8 @@ public:
     }
 
     void insert_interface_coeffs(const lduInterfaceFieldPtrsList &interfaces,
-                                 scalar *rows, scalar *cols, label &element_ctr,
-                                 const bool upper) const
+                                 int *rows, int *cols, label row,
+                                 label &element_ctr, const bool upper) const
     {
         for (int i = 0; i < interfaces.size(); i++) {
             if (interfaces.operator()(i) == nullptr) {
@@ -188,13 +188,23 @@ public:
                     }
                 }
 
+                pldui.send(Pstream::commsTypes::nonBlocking,
+                           iface->interface().faceCells());
+
+                auto otherSide_tmp =
+                    pldui.receive<label>(Pstream::commsTypes::nonBlocking,
+                                         iface->interface().faceCells().size());
+
+
                 // check if current cell is on the current patch
                 // NOTE cells can be several times on same patch
-                for (int cellI = 0;
+                for (label cellI = 0;
                      cellI < iface->interface().faceCells().size(); cellI++) {
+                    label other_side_cellID = otherSide_tmp()[cellI];
                     if (iface->interface().faceCells()[cellI] == row) {
                         rows[element_ctr] = global_cell_index_.toGlobal(row);
-                        cols[element_ctr] = 66;
+                        cols[element_ctr] = global_cell_index_.toGlobal(
+                            pldui.neighbProcNo(), other_side_cellID);
                         element_ctr++;
                     }
                 }
@@ -222,9 +232,6 @@ public:
         const auto lower = lower_local.get_const_data();
         const auto upper = upper_local.get_const_data();
 
-        // auto col_idxs_local = std::make_shared<idx_array>(ref_exec, nElems_);
-        // auto row_idxs_local = std::make_shared<idx_array>(ref_exec, nElems_);
-
         auto rows = row_idxs_.get_data();  // row_idxs_local->get_data();
         auto cols = col_idxs_.get_data();  // col_idxs_local->get_data();
 
@@ -240,7 +247,8 @@ public:
 
         for (label row = 0; row < nCells_; row++) {
             // check for lower idxs
-            insert_interface_coeffs(interfaces, rows, cols, element_ctr, true);
+            insert_interface_coeffs(interfaces, rows, cols, row, element_ctr,
+                                    true);
 
             // add lower elements
             // for now just scan till current upper ctr
@@ -287,7 +295,8 @@ public:
                 element_ctr++;
                 upper_ctr++;
             }
-            insert_interface_coeffs(interfaces, rows, cols, element_ctr, false);
+            insert_interface_coeffs(interfaces, rows, cols, row, element_ctr,
+                                    false);
         }
     }
 

--- a/common/StoppingCriterion.H
+++ b/common/StoppingCriterion.H
@@ -336,9 +336,12 @@ public:
                 frequency = max(1, minIter / 20);
             }
         }
-        // SIMPLE_LOG(verbose,
-        //            "frequency " + word(frequency) + " minIter " +
-        //            word(minIter))
+
+        word msg = "Creating stopping criterion with minIter " +
+                   std::to_string(minIter) + " frequency " +
+                   std::to_string(frequency);
+
+        LOG_1(verbose, msg)
 
         return OpenFOAMStoppingCriterion::build()
             .with_openfoam_absolute_tolerance(tolerance_)

--- a/common/common.C
+++ b/common/common.C
@@ -78,9 +78,9 @@ void set_solve_prev_iters(word sys_matrix_name_, const objectRegistry &db,
             .lookupObjectRef<IOdictionary>(solvPropsDict)
             .set<label>("prev_solve_iters", prev_solve_iters);
     } else {
-        auto gkoSolverProperties = std::make_unique<IOdictionary>(
-            IOobject(solvPropsDict, fileName("None"), db, IOobject::NO_READ,
-                     IOobject::NO_WRITE));
+        auto gkoSolverProperties =
+            new IOdictionary(IOobject(solvPropsDict, fileName("None"), db,
+                                      IOobject::NO_READ, IOobject::NO_WRITE));
         gkoSolverProperties->add("prev_solve_iters", prev_solve_iters, true);
     }
 }

--- a/common/common.H
+++ b/common/common.H
@@ -40,10 +40,11 @@ using vec = gko::matrix::Dense<scalar>;
     (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #define SIMPLE_LOG(VERBOSE, PRIO, MSG)                                     \
-    if (true) {                                                 \
+    if (VERBOSE > PRIO) {                                                  \
         if (Pstream::parRun()) {                                           \
             std::cout << "[OGL LOG][Proc: " << Pstream::myProcNo() << "][" \
-                      << __FILENAME__ << ":" << __LINE__ << "] " << MSG << std::endl;         \
+                      << __FILENAME__ << ":" << __LINE__ << "] " << MSG    \
+                      << std::endl;                                        \
         } else {                                                           \
             std::cout << "[OGL LOG][" << __FILENAME__ << "] " << MSG       \
                       << std::endl;                                        \

--- a/common/common.H
+++ b/common/common.H
@@ -40,10 +40,10 @@ using vec = gko::matrix::Dense<scalar>;
     (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #define SIMPLE_LOG(VERBOSE, PRIO, MSG)                                     \
-    if (VERBOSE >= PRIO) {                                                 \
+    if (true) {                                                 \
         if (Pstream::parRun()) {                                           \
             std::cout << "[OGL LOG][Proc: " << Pstream::myProcNo() << "][" \
-                      << __FILENAME__ << "] " << MSG << std::endl;         \
+                      << __FILENAME__ << ":" << __LINE__ << "] " << MSG << std::endl;         \
         } else {                                                           \
             std::cout << "[OGL LOG][" << __FILENAME__ << "] " << MSG       \
                       << std::endl;                                        \

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -192,20 +192,22 @@ public:
                 solverPerf.nIterations() = this->get_number_of_iterations();
                 this->store_number_of_iterations();
             }
-            std::cout << "!!!! psi before copying back" << std::endl;
-            for (int i = 0; i < psi.size(); i++) {
-                std::cout << "!!!!! " << Pstream::myProcNo() << " celli " << i
-                          << " " << psi[i] << std::endl;
-            }
+            // std::cout << "!!!! psi before copying back" << std::endl;
+            // for (int i = 0; i < psi.size(); i++) {
+            //     std::cout << "!!!!! " << Pstream::myProcNo() << " celli " <<
+            //     i
+            //               << " " << psi[i] << std::endl;
+            // }
 
             x.copy_back_parallel(this->get_global_cell_index(), &psi[0],
                                  dense_x);
 
-            std::cout << "!!!! psi after copying back" << std::endl;
-            for (int i = 0; i < psi.size(); i++) {
-                std::cout << "!!!!! " << Pstream::myProcNo() << " celli " << i
-                          << " " << psi[i] << std::endl;
-            }
+            // std::cout << "!!!! psi after copying back" << std::endl;
+            // for (int i = 0; i < psi.size(); i++) {
+            //     std::cout << "!!!!! " << Pstream::myProcNo() << " celli " <<
+            //     i
+            //               << " " << psi[i] << std::endl;
+            // }
 
         } else {
             LOG_1(verbose_, "get_gkomatrix")

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -164,29 +164,6 @@ public:
             solver_controls_.lookupOrDefault<Switch>("updateInitGuess", true),
             true};
 
-
-        // Generate solver
-        // const word timeName =
-        // this->matrix().mesh().thisDb().time().timeName();
-
-        // // if (Pstream::master()) {
-        // //     if (get_export())
-        // //         export_system(this->fieldName(), gko::lend(gkomatrix),
-        // //                       gko::lend(x[0]), gko::lend(b), timeName);
-        // // }
-
-        // SIMPLE_LOG(verbose_, "create precond")
-        // if (Pstream::master()) {
-        //     SIMPLE_TIME(
-        //         verbose_, init_preconditioner,
-        //         this->init_preconditioner(this->matrix().mesh().thisDb(),
-        //                                   gkomatrix, device_exec);)
-        // }
-        // SIMPLE_LOG(verbose_, "create precond done")
-
-        // // Instantiate an iteration logger.
-
-
         // Solve system
         if (Pstream::parRun()) {
             auto dense_x = x.get_global_dense_vec();
@@ -205,7 +182,7 @@ public:
                 LOG_1(verbose_, "create solver")
                 auto solver = solver_gen->generate(
                     gko::share(gkomatrix.get_persistent_object()));
-                LOG_1(verbose_, "solve solver")
+                LOG_1(verbose_, "solve solver done")
                 SIMPLE_TIME(
                     verbose_, solve,
                     solver->apply(gko::lend(dense_b), gko::lend(dense_x));)
@@ -215,8 +192,21 @@ public:
                 solverPerf.nIterations() = this->get_number_of_iterations();
                 this->store_number_of_iterations();
             }
+            std::cout << "!!!! psi before copying back" << std::endl;
+            for (int i = 0; i < psi.size(); i++) {
+                std::cout << "!!!!! " << Pstream::myProcNo() << " celli " << i
+                          << " " << psi[i] << std::endl;
+            }
+
             x.copy_back_parallel(this->get_global_cell_index(), &psi[0],
                                  dense_x);
+
+            std::cout << "!!!! psi after copying back" << std::endl;
+            for (int i = 0; i < psi.size(); i++) {
+                std::cout << "!!!!! " << Pstream::myProcNo() << " celli " << i
+                          << " " << psi[i] << std::endl;
+            }
+
         } else {
             LOG_1(verbose_, "get_gkomatrix")
             auto gkomatrix = csr_matrix_wrapper_.get_gkomatrix();

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -145,7 +145,7 @@ public:
 
 
         PersistentArray<scalar> b{
-            this->fieldName() + "rhs",
+            this->fieldName() + "_rhs",
             db_,
             this->get_exec_handler(),
             this->get_global_cell_index(),
@@ -155,7 +155,7 @@ public:
             true};
 
         PersistentArray<scalar> x{
-            this->fieldName() + "solution",
+            this->fieldName() + "_solution",
             db_,
             this->get_exec_handler(),
             this->get_global_cell_index(),


### PR DESCRIPTION
This PR addresses the missing matrix coefficients which are on the processor interfaces.

The following things need to be implemented:
- [x] Calculate the correct size of the gathered CSR matrix.
- [x] Update/correct interface sparsity pattern after gathering
- [x] Update matrix values