### PR TITLE
Device persisent vector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,8 +125,7 @@ target_sources(
           HostMatrix/HostMatrix.C
           Solver/CG/GKOCG.C
           Solver/BiCGStab/GKOBiCGStab.C
-          # Solver/IR/GKOIR.C
-          Solver/Multigrid/GKOMultigrid.C
+          # Solver/IR/GKOIR.C Solver/Multigrid/GKOMultigrid.C
           Solver/GMRES/GKOGMRES.C
           LduMatrix/GKOACG/GKOACG.C
   PUBLIC common/common.H
@@ -144,7 +143,7 @@ target_sources(
          BaseWrapper/CoupledLduBase/GKOCoupledLduBase.H
          Solver/CG/GKOCG.H
          Solver/IR/GKOIR.H
-         Solver/Multigrid/GKOMultigrid.H
+         # Solver/Multigrid/GKOMultigrid.H
          Solver/BiCGStab/GKOBiCGStab.H
          Solver/GMRES/GKOGMRES.H
          LduMatrix/GKOACG/GKOACG.H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ target_sources(
           StoppingCriterion/StoppingCriterion.C
           DevicePersistent/DevicePersistentBase/DevicePersistentBase.C
           DevicePersistent/DevicePersistentArray/DevicePersistentArray.C
+          DevicePersistent/DevicePersistentVector/DevicePersistentVector.C
           DevicePersistent/ExecutorHandler/ExecutorHandler.C
           DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.C
           Preconditioner/Preconditioner.C
@@ -134,6 +135,7 @@ target_sources(
          HostMatrix/HostMatrix.H
          DevicePersistent/DevicePersistentBase/DevicePersistentBase.H
          DevicePersistent/DevicePersistentArray/DevicePersistentArray.H
+         DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
          DevicePersistent/ExecutorHandler/ExecutorHandler.H
          DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
          Preconditioner/Preconditioner.H

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -30,6 +30,7 @@ SourceFiles
 #include "fvCFD.H"
 
 #include "../DevicePersistentArray/DevicePersistentArray.H"
+#include "../DevicePersistentVector/DevicePersistentVector.H"
 #include "../ExecutorHandler/ExecutorHandler.H"
 #include "../IOGlobalIndex/gkoGlobalIndex.H"
 

--- a/DevicePersistent/DevicePersistentBase/DevicePersistentBase.C
+++ b/DevicePersistent/DevicePersistentBase/DevicePersistentBase.C
@@ -10,6 +10,9 @@ defineTemplateTypeNameWithName(DevicePersistentBase<gko::matrix::Csr<scalar>>,
                                "PersistentCSRMatrix");
 defineTemplateTypeNameWithName(DevicePersistentBase<gko::Array<scalar>>,
                                "PersistentScalarArray");
+defineTemplateTypeNameWithName(
+    DevicePersistentBase<gko::distributed::Vector<scalar>>,
+    "PersistentScalarVector");
 defineTemplateTypeNameWithName(DevicePersistentBase<gko::Array<label>>,
                                "PersistentLabelArray");
 defineTemplateTypeNameWithName(DevicePersistentBase<gko::matrix::Dense<label>>,

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.C
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.C
@@ -1,0 +1,3 @@
+#include "DevicePersistentVector.H"
+
+namespace Foam {}  // namespace Foam

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -205,11 +205,12 @@ public:
         auto host_buffer =
             gko::matrix::Dense<T>::create(exec_.get_ref_exec(), local_size);
 
+        host_buffer->copy_from(get_vector()->get_const_local());
         // host_view = device_view;
-        host_exec->copy_from(
-            device_exec.get(), local_size,
-            get_vector()->get_const_local()->get_const_values(),
-            host_buffer->get_values());
+        // host_exec->copy_from(
+        //     device_exec.get(), local_size,
+        //     get_vector()->get_const_local()->get_const_values(),
+        //     host_buffer->get_values());
 
         auto host_buffer_view = gko::Array<T>::view(
             exec_.get_ref_exec(), local_size, host_buffer->get_values());

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -1,0 +1,215 @@
+/*---------------------------------------------------------------------------*\
+License
+    This file is part of OGL.
+
+    OGL is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OGL is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OGL.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::DevicePersistentVector
+
+Author: Gregor Olenik <go@hpsim.de>
+
+SourceFiles
+    DevicePersistentVector.H
+
+\*---------------------------------------------------------------------------*/
+#ifndef OGL_DevicePersistentVector_INCLUDED_H
+#define OGL_DevicePersistentVector_INCLUDED_H
+
+#include <functional>
+
+#include <ginkgo/ginkgo.hpp>
+#include "../DevicePersistentBase/DevicePersistentBase.H"
+#include "../ExecutorHandler/ExecutorHandler.H"
+
+#include "../common/common.H"
+
+namespace Foam {
+
+
+template <class T>
+struct VectorInitFunctor {
+    using dist_vec = gko::distributed::Vector<scalar>;
+
+    const word name_;
+
+    const ExecutorHandler &exec_;
+
+    const std::shared_ptr<gko::distributed::Partition<label>> partition_;
+
+    const label verbose_;
+
+    const bool on_device_;
+
+    // Memory from which array will be initialised
+    const T *other_;
+
+
+    VectorInitFunctor(
+        const ExecutorHandler &exec, const word name,
+        const std::shared_ptr<gko::distributed::Partition<label>> partition,
+        const label verbose, const bool on_device = false)
+        : exec_(exec),
+          name_(name),
+          partition_(partition),
+          on_device_(on_device),
+          verbose_(verbose),
+          other_(NULL)
+    {}
+
+    VectorInitFunctor(
+        const ExecutorHandler &exec, const word name,
+        const std::shared_ptr<gko::distributed::Partition<label>> partition,
+        const T *other, const label verbose, const bool on_device = false)
+        : exec_(exec),
+          name_(name),
+          partition_(partition),
+          on_device_(on_device),
+          verbose_(verbose),
+          other_(other)
+    {}
+
+
+    // update persistent array from host memory
+    void update(
+        std::shared_ptr<gko::distributed::Vector<T>> persistent_array) const
+    {
+        word msg{"updating array " + name_ + " of size " +
+                 std::to_string(partition_.localSize())};
+        LOG_1(verbose_, msg)
+
+        auto host_exec = exec_.get_ref_exec();
+        auto device_exec = exec_.get_device_exec();
+        auto comm = exec_.get_gko_mpi_comm_wrapper();
+        const auto local_size = partition_->get_part_size(comm->rank());
+        auto exec =
+            (on_device_) ? exec_.get_device_exec() : exec_.get_ref_exec();
+
+        host_exec->copy_from(
+            exec.get(), local_size,
+            get_vector()->get_const_local()->get_const_values(), memory_);
+    }
+
+    std::shared_ptr<gko::distributed::Vector<T>> init() const
+    {
+        auto exec =
+            (on_device_) ? exec_.get_device_exec() : exec_.get_ref_exec();
+        word msg{"initialising vector " + name_ + " of size " +
+                 std::to_string(partition_->get_size())};
+        msg += (on_device_) ? " on device" : " on host";
+        LOG_1(verbose_, msg)
+
+        auto host_view =
+            gko::Array<T>::view(exec_.get_ref_exec(), partition_->get_size(),
+                                const_cast<T *>(other_));
+
+        return gko::share(dist_vec::from_local<label, gko::int64>(
+            exec, *exec_.get_gko_mpi_comm_wrapper().get(), host_view,
+            partition_.get()));
+    }
+};
+
+template <class T>
+class PersistentVector
+    : public PersistentBase<gko::distributed::Vector<T>, VectorInitFunctor<T>> {
+    using vec = gko::matrix::Dense<scalar>;
+
+    T *memory_;
+
+    const std::shared_ptr<gko::distributed::Partition<label>> partition_;
+
+    const ExecutorHandler &exec_;
+
+    // indicating if the underlying array needs to
+    // updated even if was found in the object registry
+    const bool update_;
+
+    // The same as dpb but for the global data
+    // NOTE if on the host:
+    //  - This should exist with the full length only on the master
+    // on the device:
+    //  - global data is needed on the device for example for the
+    //    col and row idxs
+    mutable std::shared_ptr<gko::matrix::Dense<T>> persistent_object_global_{};
+
+
+public:
+    /* PersistentVector constructor using existing memory
+     *
+     * @param memory ptr to memory on host from which the gko array is
+     *               initialized
+     * @param name name of the underlying field or data
+     * @param objectRegistry reference to registry for storage
+     * @param exec executor handler
+     * @param verbose whether to print infos out
+     * @param update whether to update the underlying array if found in registry
+     * @param init_on_device whether the array is to be initialized on the
+     * device or host
+     */
+    PersistentVector(
+        T *memory, const word name, const objectRegistry &db,
+        const ExecutorHandler &exec,
+        const std::shared_ptr<gko::distributed::Partition<label>> partition,
+        const label verbose, const bool update, const bool init_on_device)
+        : PersistentBase<gko::distributed::Vector<T>, VectorInitFunctor<T>>(
+              name, db,
+              VectorInitFunctor<T>(exec, name, partition, memory, verbose,
+                                   init_on_device),
+              update, verbose),
+          memory_(memory),
+          partition_(partition),
+          exec_(exec),
+          update_(update)
+    {}
+
+    // label get_global_size() const { return partition_.size(); }
+
+    bool get_update() const { return update_; }
+
+    T *get_data() const { return this->get_persistent_object()->get_data(); }
+
+    void set_data(T *data)
+    {
+        this->get_persistent_object()->get_data() = data;
+    };
+
+    const T *get_const_data() const
+    {
+        return this->get_persistent_object()->get_const_data();
+    };
+
+
+    std::shared_ptr<gko::distributed::Vector<T>> get_vector() const
+    {
+        return this->get_persistent_object();
+    }
+
+    void copy_back()
+    {
+        auto host_exec = exec_.get_ref_exec();
+        auto device_exec = exec_.get_device_exec();
+        auto comm = exec_.get_gko_mpi_comm_wrapper();
+        const auto local_size = partition_->get_part_size(comm->rank());
+
+        host_exec->copy_from(
+            device_exec.get(), local_size,
+            get_vector()->get_const_local()->get_const_values(), memory_);
+    }
+
+    const ExecutorHandler &get_exec_handler() const { return exec_; }
+};
+
+}  // namespace Foam
+
+#endif

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -202,9 +202,16 @@ public:
         auto comm = exec_.get_gko_mpi_comm_wrapper();
         const auto local_size = partition_->get_part_size(comm->rank());
 
-        host_exec->copy_from(
-            device_exec.get(), local_size,
-            get_vector()->get_const_local()->get_const_values(), memory_);
+        auto device_view = gko::Array<T>::view(
+            device_exec, local_size, get_vector()->get_local()->get_values());
+
+        auto host_view = gko::Array<T>::view(exec_.get_ref_exec(), local_size,
+                                             const_cast<T *>(memory_));
+
+        host_view = device_view;
+        // host_exec->copy_from(
+        //     device_exec.get(), local_size,
+        //     get_vector()->get_const_local()->get_const_values(), host_);
     }
 
     const ExecutorHandler &get_exec_handler() const { return exec_; }

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -104,14 +104,15 @@ struct VectorInitFunctor {
     {
         auto exec =
             (on_device_) ? exec_.get_device_exec() : exec_.get_ref_exec();
+        auto comm = exec_.get_gko_mpi_comm_wrapper();
+        const auto local_size = partition_->get_part_size(comm->rank());
         word msg{"initialising vector " + name_ + " of size " +
-                 std::to_string(partition_->get_size())};
+                 std::to_string(local_size)};
         msg += (on_device_) ? " on device" : " on host";
         LOG_1(verbose_, msg)
 
-        auto host_view =
-            gko::Array<T>::view(exec_.get_ref_exec(), partition_->get_size(),
-                                const_cast<T *>(other_));
+        auto host_view = gko::Array<T>::view(exec_.get_ref_exec(), local_size,
+                                             const_cast<T *>(other_));
 
         return gko::share(dist_vec::from_local<label, gko::int64>(
             exec, *exec_.get_gko_mpi_comm_wrapper().get(), host_view,

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -83,22 +83,21 @@ struct VectorInitFunctor {
 
     // update persistent array from host memory
     void update(
-        std::shared_ptr<gko::distributed::Vector<T>> persistent_array) const
+        std::shared_ptr<gko::distributed::Vector<T>> persistent_vector) const
     {
+        auto comm = exec_.get_gko_mpi_comm_wrapper();
+        const auto local_size = partition_->get_part_size(comm->rank());
         word msg{"updating array " + name_ + " of size " +
-                 std::to_string(partition_.localSize())};
+                 std::to_string(local_size)};
         LOG_1(verbose_, msg)
 
         auto host_exec = exec_.get_ref_exec();
         auto device_exec = exec_.get_device_exec();
-        auto comm = exec_.get_gko_mpi_comm_wrapper();
-        const auto local_size = partition_->get_part_size(comm->rank());
         auto exec =
             (on_device_) ? exec_.get_device_exec() : exec_.get_ref_exec();
 
-        host_exec->copy_from(
-            exec.get(), local_size,
-            get_vector()->get_const_local()->get_const_values(), memory_);
+        host_exec->copy_from(exec.get(), local_size, other_,
+                             persistent_vector->get_local()->get_values());
     }
 
     std::shared_ptr<gko::distributed::Vector<T>> init() const

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -202,16 +202,22 @@ public:
         auto comm = exec_.get_gko_mpi_comm_wrapper();
         const auto local_size = partition_->get_part_size(comm->rank());
 
-        auto device_view = gko::Array<T>::view(
-            device_exec, local_size, get_vector()->get_local()->get_values());
+        auto host_buffer =
+            gko::matrix::Dense<T>::create(exec_.get_ref_exec(), local_size);
+
+        // host_view = device_view;
+        host_exec->copy_from(
+            device_exec.get(), local_size,
+            get_vector()->get_const_local()->get_const_values(),
+            host_buffer->get_values());
+
+        auto host_buffer_view = gko::Array<T>::view(
+            exec_.get_ref_exec(), local_size, host_buffer->get_values());
 
         auto host_view = gko::Array<T>::view(exec_.get_ref_exec(), local_size,
                                              const_cast<T *>(memory_));
 
-        host_view = device_view;
-        // host_exec->copy_from(
-        //     device_exec.get(), local_size,
-        //     get_vector()->get_const_local()->get_const_values(), host_);
+        host_view = host_buffer_view;
     }
 
     const ExecutorHandler &get_exec_handler() const { return exec_; }

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -40,6 +40,7 @@ namespace Foam {
 
 template <class T>
 struct VectorInitFunctor {
+    using vec = gko::matrix::Dense<scalar>;
     using dist_vec = gko::distributed::Vector<scalar>;
 
     const word name_;
@@ -97,7 +98,7 @@ struct VectorInitFunctor {
             (on_device_) ? exec_.get_device_exec() : exec_.get_ref_exec();
 
         host_exec->copy_from(exec.get(), local_size, other_,
-                             persistent_vector->get_local()->get_values());
+                             persistent_vector->get_local_values());
     }
 
     std::shared_ptr<gko::distributed::Vector<T>> init() const
@@ -114,9 +115,9 @@ struct VectorInitFunctor {
         auto host_view = gko::Array<T>::view(exec_.get_ref_exec(), local_size,
                                              const_cast<T *>(other_));
 
-        return gko::share(dist_vec::from_local<label, gko::int64>(
-            exec, *exec_.get_gko_mpi_comm_wrapper().get(), host_view,
-            partition_.get()));
+        return gko::share(dist_vec::create(
+            exec, *exec_.get_gko_mpi_comm_wrapper().get(),
+            vec::create(exec, gko::dim<2>{local_size, 1}, host_view, 1).get()));
     }
 };
 
@@ -205,7 +206,7 @@ public:
         auto host_buffer =
             gko::matrix::Dense<T>::create(exec_.get_ref_exec(), local_size);
 
-        host_buffer->copy_from(get_vector()->get_const_local());
+        host_buffer->copy_from(get_vector()->get_local_vector());
         // host_view = device_view;
         // host_exec->copy_from(
         //     device_exec.get(), local_size,

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -203,8 +203,8 @@ public:
         auto comm = exec_.get_gko_mpi_comm_wrapper();
         const auto local_size = partition_->get_part_size(comm->rank());
 
-        auto host_buffer =
-            gko::matrix::Dense<T>::create(exec_.get_ref_exec(), local_size);
+        auto host_buffer = gko::matrix::Dense<T>::create(
+            exec_.get_ref_exec(), gko::dim<2>{local_size, 1});
 
         host_buffer->copy_from(get_vector()->get_local_vector());
         // host_view = device_view;

--- a/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
+++ b/DevicePersistent/DevicePersistentVector/DevicePersistentVector.H
@@ -125,7 +125,7 @@ class PersistentVector
     : public PersistentBase<gko::distributed::Vector<T>, VectorInitFunctor<T>> {
     using vec = gko::matrix::Dense<scalar>;
 
-    T *memory_;
+    const T *memory_;
 
     const std::shared_ptr<gko::distributed::Partition<label>> partition_;
 
@@ -158,7 +158,7 @@ public:
      * device or host
      */
     PersistentVector(
-        T *memory, const word name, const objectRegistry &db,
+        const T *memory, const word name, const objectRegistry &db,
         const ExecutorHandler &exec,
         const std::shared_ptr<gko::distributed::Partition<label>> partition,
         const label verbose, const bool update, const bool init_on_device)

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -67,7 +67,7 @@ struct ExecutorInitFunctor {
         if (executor_name_ == "cuda") {
             return gko::share(gko::CudaExecutor::create(
                 device_id_ % gko::CudaExecutor::get_num_devices(), host_exec,
-                true));
+                false, gko::allocation_mode::device));
         }
         if (executor_name_ == "dpcpp") {
             return gko::share(gko::DpcppExecutor::create(

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -367,7 +367,6 @@ void HostMatrixWrapper<MatrixType>::update_host_matrix_data(
         const fileName path = permutation_matrix_name_;
         auto po = new DevicePersistentBase<gko::LinOp>(IOobject(path, db), P_);
     }
-    // END TODO
 
     // unsorted entries on device
     auto d = vec::create(device_exec, gko::dim<2>(nElems_, 1));

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -359,9 +359,8 @@ void HostMatrixWrapper<MatrixType>::update_host_matrix_data(
     const auto sorting_idxs = ldu_csr_idx_mapping_.get_array();
     auto device_exec = exec_.get_device_exec();
 
+    auto &db = values_.get_db();
     if (!permutation_stored_) {
-        auto &db = values_.get_db();
-
         P_ = gko::share(gko::matrix::Permutation<label>::create(
             device_exec, gko::dim<2>{nElems_}, *sorting_idxs.get()));
         const fileName path = permutation_matrix_name_;
@@ -370,6 +369,16 @@ void HostMatrixWrapper<MatrixType>::update_host_matrix_data(
 
     // unsorted entries on device
     auto d = vec::create(device_exec, gko::dim<2>(nElems_, 1));
+    const bool csr_stored{db.template foundObject<regIOobject>("pcsr")};
+    // std::shared_ptr<vec> d{};
+    // if (csr_stored) {
+    //     auto values_view = val_array::view(
+    //         values_.get_exec_handler().get_device_exec(),
+    //         values_.get_global_size(), csr_matrix->get_values());
+    // } else {
+    //     d = gko::share(vec::create(device_exec, gko::dim<2>(nElems_, 1)));
+    // }
+
 
     // copy upper
     auto upper = this->matrix().upper();

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -65,12 +65,12 @@ public:
     std::shared_ptr<gko::LinOp> wrap_schwarz(
         std::shared_ptr<gko::LinOp> gkomatrix,
         std::shared_ptr<gko::Executor> device_exec,
-        std::shared_ptr<PrecondFactory> precond) const
+        std::unique_ptr<PrecondFactory> precond) const
     {
         using ras = gko::preconditioner::Schwarz<scalar, label>;
         if (Pstream::parRun()) {
             return gko::share(ras::build()
-                                  .with_inner_solver(precond)
+                                  .with_inner_solver(std::move(precond))
                                   .on(device_exec)
                                   ->generate(gkomatrix));
         }
@@ -94,12 +94,11 @@ public:
                        std::to_string(max_block_size);
             LOG_1(verbose_, msg)
 
-            auto pre_factory =
-                gko::share(bj::build()
-                               .with_skip_sorting(skip_sorting)
-                               .with_max_block_size(max_block_size)
-                               .on(device_exec));
-            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+            auto pre_factory = bj::build()
+                                   .with_skip_sorting(skip_sorting)
+                                   .with_max_block_size(max_block_size)
+                                   .on(device_exec);
+            return wrap_schwarz(gkomatrix, device_exec, std::move(pre_factory));
         }
         if (name == "ILU") {
             auto factorizaton_factory =
@@ -117,20 +116,15 @@ public:
                     .on(device_exec);
 
             // Use incomplete factors to generate ILU preconditioner auto
-            return gko::share(ilu_pre_factory->generate(
-                gko::share(factorizaton_factory->generate(gkomatrix))));
+            return wrap_schwarz(
+                gko::share(factorizaton_factory->generate(gkomatrix)),
+                device_exec, std::move(ilu_pre_factory));
         }
         if (name == "IRILU") {
-            auto factorizaton_factory =
-                gko::factorization::Ilu<scalar, label>::build()
-                    .with_skip_sorting(skip_sorting)
-                    .on(device_exec);
-
-
             auto trisolve_factory =
                 ir::build()
-                    .with_solver(share(
-                        bj::build().with_max_block_size(1).on(device_exec)))
+                    .with_solver(
+                        bj::build().with_max_block_size(1).on(device_exec))
                     .with_criteria(
                         gko::stop::Iteration::build().with_max_iters(5).on(
                             device_exec))
@@ -147,9 +141,15 @@ public:
                     .with_u_solver_factory(gko::clone(trisolve_factory))
                     .on(device_exec);
 
+            auto factorizaton_factory =
+                gko::factorization::Ilu<scalar, label>::build()
+                    .with_skip_sorting(skip_sorting)
+                    .on(device_exec);
+
             // Use incomplete factors to generate ILU preconditioner
-            return gko::share(ilu_pre_factory->generate(gko::share(
-                gko::share(factorizaton_factory->generate(gkomatrix)))));
+            return wrap_schwarz(
+                gko::share(factorizaton_factory->generate(gkomatrix)),
+                device_exec, std::move(ilu_pre_factory));
         }
         if (name == "IC") {
             auto factorizaton_factory =
@@ -160,12 +160,11 @@ public:
             word msg = "Generate preconditioner " + name;
             LOG_1(verbose_, msg)
 
-
             auto ic = gko::share(factorizaton_factory->generate(gkomatrix));
             auto pre_factory =
-                gko::share(gko::preconditioner::Ic<>::build().on(device_exec));
+                gko::preconditioner::Ic<>::build().on(device_exec);
 
-            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+            return wrap_schwarz(gkomatrix, device_exec, std::move(pre_factory));
         }
         if (name == "ISAI") {
             label sparsity_power(
@@ -175,14 +174,14 @@ public:
                        std::to_string(sparsity_power);
             LOG_1(verbose_, msg)
 
-            auto pre_factory = gko::share(
+            auto pre_factory =
                 gko::preconditioner::Isai<gko::preconditioner::isai_type::spd,
                                           scalar, label>::build()
                     .with_skip_sorting(skip_sorting)
                     .with_sparsity_power(sparsity_power)
-                    .on(device_exec));
+                    .on(device_exec);
 
-            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+            return wrap_schwarz(gkomatrix, device_exec, std::move(pre_factory));
         }
         if (name == "Multigrid") {
             using ir = gko::solver::Ir<scalar>;
@@ -247,22 +246,22 @@ public:
                        std::to_string(zeroGuess);
             LOG_1(verbose_, msg)
 
-            auto pre_factory = gko::share(
+            auto pre_factory =
                 mg::build()
                     .with_max_levels(max_levels)
                     .with_min_coarse_rows(min_coarse_rows)
                     .with_pre_smoother(smoother_gen)
                     .with_post_uses_pre(true)
-                    .with_mg_level(gko::share(
+                    .with_mg_level(
                         amgx_pgm::build().with_deterministic(true).on(
-                            device_exec)))
+                            device_exec))
                     .with_coarsest_solver(coarsest_gen)
                     .with_zero_guess(zeroGuess)
                     .with_criteria(
                         gko::stop::Iteration::build().with_max_iters(1u).on(
                             device_exec))
-                    .on(device_exec));
-            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+                    .on(device_exec);
+            return wrap_schwarz(gkomatrix, device_exec, std::move(pre_factory));
         }
         return {};
     }

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -101,60 +101,65 @@ public:
                                .on(device_exec));
             return wrap_schwarz(gkomatrix, device_exec, pre_factory);
         }
-        if (name == "ILU") {
-            auto factorizaton_factory =
-                gko::factorization::Ilu<scalar, label>::build()
-                    .with_skip_sorting(skip_sorting)
-                    .on(device_exec);
+        // if (name == "ILU") {
+        //     auto factorizaton_factory =
+        //         gko::factorization::Ilu<scalar, label>::build()
+        //             .with_skip_sorting(skip_sorting)
+        //             .on(device_exec);
 
-            auto par_ilu =
-                gko::share(factorizaton_factory->generate(gkomatrix));
+        //     auto par_ilu =
+        //         gko::share(factorizaton_factory->generate(gkomatrix));
 
-            word msg = "Generate preconditioner " + name;
-            LOG_1(verbose_, msg)
+        //     word msg = "Generate preconditioner " + name;
+        //     LOG_1(verbose_, msg)
 
 
-            auto ilu_pre_factory =
-                gko::preconditioner::Ilu<gko::solver::LowerTrs<scalar, label>,
-                                         gko::solver::UpperTrs<scalar, label>,
-                                         false>::build()
-                    .on(device_exec);
+        //     auto ilu_pre_factory =
+        //         gko::preconditioner::Ilu<gko::solver::LowerTrs<scalar,
+        //         label>,
+        //                                  gko::solver::UpperTrs<scalar,
+        //                                  label>, false>::build()
+        //             .on(device_exec);
 
-            // Use incomplete factors to generate ILU preconditioner auto
-            return gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
-        }
-        if (name == "IRILU") {
-            auto factorizaton_factory =
-                gko::factorization::Ilu<scalar, label>::build()
-                    .with_skip_sorting(skip_sorting)
-                    .on(device_exec);
+        //     // Use incomplete factors to generate ILU preconditioner auto
+        //     return
+        //     gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
+        // }
+        // if (name == "IRILU") {
+        //     auto factorizaton_factory =
+        //         gko::factorization::Ilu<scalar, label>::build()
+        //             .with_skip_sorting(skip_sorting)
+        //             .on(device_exec);
 
-            auto par_ilu =
-                gko::share(factorizaton_factory->generate(gkomatrix));
+        //     auto par_ilu =
+        //         gko::share(factorizaton_factory->generate(gkomatrix));
 
-            auto bj_factory =
-                bj::build().with_max_block_size(1).on(device_exec);
+        //     auto bj_factory =
+        //         bj::build().with_max_block_size(1).on(device_exec);
 
-            auto trisolve_factory =
-                ir::build()
-                    .with_solver(share(bj_factory))
-                    .with_criteria(
-                        gko::stop::Iteration::build().with_max_iters(5).on(
-                            device_exec))
-                    .on(device_exec);
+        //     auto trisolve_factory =
+        //         ir::build()
+        //             .with_solver(share(bj_factory))
+        //             .with_criteria(
+        //                 gko::stop::Iteration::build().with_max_iters(5).on(
+        //                     device_exec))
+        //             .on(device_exec);
 
-            // Generate an ILU preconditioner factory by setting lower and upper
-            // triangular solver - in this case the previously defined iterative
-            // refinement method.
-            auto ilu_pre_factory =
-                gko::preconditioner::Ilu<ir, ir>::build()
-                    .with_l_solver_factory(gko::clone(trisolve_factory))
-                    .with_u_solver_factory(gko::clone(trisolve_factory))
-                    .on(device_exec);
+        //     // Generate an ILU preconditioner factory by setting lower and
+        //     upper
+        //     // triangular solver - in this case the previously defined
+        //     iterative
+        //     // refinement method.
+        //     auto ilu_pre_factory =
+        //         gko::preconditioner::Ilu<ir, ir>::build()
+        //             .with_l_solver_factory(gko::clone(trisolve_factory))
+        //             .with_u_solver_factory(gko::clone(trisolve_factory))
+        //             .on(device_exec);
 
-            // Use incomplete factors to generate ILU preconditioner
-            return gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
-        }
+        //     // Use incomplete factors to generate ILU preconditioner
+        //     return
+        //     gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
+        // }
         if (name == "IC") {
             auto factorizaton_factory =
                 gko::factorization::Ic<scalar, label>::build()
@@ -188,83 +193,85 @@ public:
 
             return wrap_schwarz(gkomatrix, device_exec, pre_factory);
         }
-        if (name == "Multigrid") {
-            using ir = gko::solver::Ir<scalar>;
-            using cg = gko::solver::Cg<scalar>;
-            using mg = gko::solver::Multigrid;
-            using bj = gko::preconditioner::Jacobi<scalar, label>;
-            using amgx_pgm = gko::multigrid::AmgxPgm<scalar, label>;
+        // if (name == "Multigrid") {
+        //     using ir = gko::solver::Ir<scalar>;
+        //     using cg = gko::solver::Cg<scalar>;
+        //     using mg = gko::solver::Multigrid;
+        //     using bj = gko::preconditioner::Jacobi<scalar, label>;
+        //     using amgx_pgm = gko::multigrid::AmgxPgm<scalar, label>;
 
-            auto inner_solver_gen =
-                gko::share(bj::build().with_max_block_size(1u).on(device_exec));
+        //     auto inner_solver_gen =
+        //         gko::share(bj::build().with_max_block_size(1u).on(device_exec));
 
-            auto smoother_gen = gko::share(
-                ir::build()
-                    .with_solver(inner_solver_gen)
-                    .with_relaxation_factor(0.9)
-                    .with_criteria(
-                        gko::stop::Iteration::build().with_max_iters(2u).on(
-                            device_exec))
-                    .on(device_exec));
+        //     auto smoother_gen = gko::share(
+        //         ir::build()
+        //             .with_solver(inner_solver_gen)
+        //             .with_relaxation_factor(0.9)
+        //             .with_criteria(
+        //                 gko::stop::Iteration::build().with_max_iters(2u).on(
+        //                     device_exec))
+        //             .on(device_exec));
 
-            // Create MultigridLevel factory
-            auto mg_level_gen =
-                amgx_pgm::build().with_deterministic(true).on(device_exec);
+        //     // Create MultigridLevel factory
+        //     auto mg_level_gen =
+        //         amgx_pgm::build().with_deterministic(true).on(device_exec);
 
-            // Create CoarsestSolver factory
-            // std::shared_ptr<gko::LinOp> coarsest_gen;
-            // coarsest_gen =
-            //     (solverControls_.lookupOrDefault("PreconditionerMultigridUseIR",
-            //                                      word("IR")) == "IR")
-            //         ? gko::share(
-            //               ir::build()
-            //                   .with_solver(inner_solver_gen)
-            //                   .with_relaxation_factor(0.9)
-            //                   .with_criteria(gko::stop::Iteration::build()
-            //                                      .with_max_iters(4u)
-            //                                      .on(device_exec))
-            //                   .on(device_exec))
-            //         : gko::share(
-            //               cg::build()
-            //                   .with_criteria(gko::stop::Iteration::build()
-            //                                      .with_max_iters(4u)
-            //                                      .on(device_exec))
-            //                   .on(device_exec));
+        //     // Create CoarsestSolver factory
+        //     // std::shared_ptr<gko::LinOp> coarsest_gen;
+        //     // coarsest_gen =
+        //     //
+        //     (solverControls_.lookupOrDefault("PreconditionerMultigridUseIR",
+        //     //                                      word("IR")) == "IR")
+        //     //         ? gko::share(
+        //     //               ir::build()
+        //     //                   .with_solver(inner_solver_gen)
+        //     //                   .with_relaxation_factor(0.9)
+        //     //                   .with_criteria(gko::stop::Iteration::build()
+        //     //                                      .with_max_iters(4u)
+        //     //                                      .on(device_exec))
+        //     //                   .on(device_exec))
+        //     //         : gko::share(
+        //     //               cg::build()
+        //     //                   .with_criteria(gko::stop::Iteration::build()
+        //     //                                      .with_max_iters(4u)
+        //     //                                      .on(device_exec))
+        //     //                   .on(device_exec));
 
-            auto coarsest_gen = gko::share(
-                cg::build()
-                    .with_criteria(
-                        gko::stop::Iteration::build().with_max_iters(4u).on(
-                            device_exec))
-                    .on(device_exec));
+        //     auto coarsest_gen = gko::share(
+        //         cg::build()
+        //             .with_criteria(
+        //                 gko::stop::Iteration::build().with_max_iters(4u).on(
+        //                     device_exec))
+        //             .on(device_exec));
 
-            // Create multigrid factory
-            label max_levels(controls.lookupOrDefault("MaxLevels", label(9)));
-            label min_coarse_rows(
-                controls.lookupOrDefault("MinCoarseRows", label(10)));
-            bool zeroGuess(controls.lookupOrDefault<Switch>("ZeroGuess", true));
+        //     // Create multigrid factory
+        //     label max_levels(controls.lookupOrDefault("MaxLevels",
+        //     label(9))); label min_coarse_rows(
+        //         controls.lookupOrDefault("MinCoarseRows", label(10)));
+        //     bool zeroGuess(controls.lookupOrDefault<Switch>("ZeroGuess",
+        //     true));
 
-            word msg = "Generate preconditioner " + name + " MaxLevels " +
-                       std::to_string(max_levels) + " MinCoarseRows " +
-                       std::to_string(min_coarse_rows) + " ZeroGuess " +
-                       std::to_string(zeroGuess);
-            LOG_1(verbose_, msg)
+        //     word msg = "Generate preconditioner " + name + " MaxLevels " +
+        //                std::to_string(max_levels) + " MinCoarseRows " +
+        //                std::to_string(min_coarse_rows) + " ZeroGuess " +
+        //                std::to_string(zeroGuess);
+        //     LOG_1(verbose_, msg)
 
-            auto pre_factory = gko::share(
-                mg::build()
-                    .with_max_levels(max_levels)
-                    .with_min_coarse_rows(min_coarse_rows)
-                    .with_pre_smoother(smoother_gen)
-                    .with_post_uses_pre(true)
-                    .with_mg_level(gko::share(mg_level_gen))
-                    .with_coarsest_solver(coarsest_gen)
-                    .with_zero_guess(zeroGuess)
-                    .with_criteria(
-                        gko::stop::Iteration::build().with_max_iters(1u).on(
-                            device_exec))
-                    .on(device_exec));
-            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
-        }
+        //     auto pre_factory = gko::share(
+        //         mg::build()
+        //             .with_max_levels(max_levels)
+        //             .with_min_coarse_rows(min_coarse_rows)
+        //             .with_pre_smoother(smoother_gen)
+        //             .with_post_uses_pre(true)
+        //             .with_mg_level(gko::share(mg_level_gen))
+        //             .with_coarsest_solver(coarsest_gen)
+        //             .with_zero_guess(zeroGuess)
+        //             .with_criteria(
+        //                 gko::stop::Iteration::build().with_max_iters(1u).on(
+        //                     device_exec))
+        //             .on(device_exec));
+        //     return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+        // }
         return {};
     }
 
@@ -307,19 +314,18 @@ public:
                         precond_store_name)
                     .get_ptr();
             } else {
-                auto prev_precond = db_
-                    .template lookupObjectRef<DevicePersistentBase<gko::LinOp>>(
-                        precond_store_name);
-		const label caching_period =
-		    controls.lookupOrDefault<label>("Caching", 0);
-		set_next_caching(sys_matrix_name_, db_, caching_period);
+                auto prev_precond = db_.template lookupObjectRef<
+                    DevicePersistentBase<gko::LinOp>>(precond_store_name);
+                const label caching_period =
+                    controls.lookupOrDefault<label>("Caching", 0);
+                set_next_caching(sys_matrix_name_, db_, caching_period);
 
-		auto generated_precond =
-		    init_preconditioner_impl(name, controls, gkomatrix, device_exec);
+                auto generated_precond = init_preconditioner_impl(
+                    name, controls, gkomatrix, device_exec);
 
-		auto precond_ptr = prev_precond.get_ptr();
-	        precond_ptr = generated_precond;
-		return precond_ptr;
+                auto precond_ptr = prev_precond.get_ptr();
+                precond_ptr = generated_precond;
+                return precond_ptr;
             }
         }
         const label caching_period =

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -101,65 +101,56 @@ public:
                                .on(device_exec));
             return wrap_schwarz(gkomatrix, device_exec, pre_factory);
         }
-        // if (name == "ILU") {
-        //     auto factorizaton_factory =
-        //         gko::factorization::Ilu<scalar, label>::build()
-        //             .with_skip_sorting(skip_sorting)
-        //             .on(device_exec);
+        if (name == "ILU") {
+            auto factorizaton_factory =
+                gko::factorization::Ilu<scalar, label>::build()
+                    .with_skip_sorting(skip_sorting)
+                    .on(device_exec);
 
-        //     auto par_ilu =
-        //         gko::share(factorizaton_factory->generate(gkomatrix));
+            word msg = "Generate preconditioner " + name;
+            LOG_1(verbose_, msg)
 
-        //     word msg = "Generate preconditioner " + name;
-        //     LOG_1(verbose_, msg)
+            auto ilu_pre_factory =
+                gko::preconditioner::Ilu<gko::solver::LowerTrs<scalar, label>,
+                                         gko::solver::UpperTrs<scalar, label>,
+                                         false>::build()
+                    .on(device_exec);
+
+            // Use incomplete factors to generate ILU preconditioner auto
+            return gko::share(ilu_pre_factory->generate(
+                gko::share(factorizaton_factory->generate(gkomatrix))));
+        }
+        if (name == "IRILU") {
+            auto factorizaton_factory =
+                gko::factorization::Ilu<scalar, label>::build()
+                    .with_skip_sorting(skip_sorting)
+                    .on(device_exec);
 
 
-        //     auto ilu_pre_factory =
-        //         gko::preconditioner::Ilu<gko::solver::LowerTrs<scalar,
-        //         label>,
-        //                                  gko::solver::UpperTrs<scalar,
-        //                                  label>, false>::build()
-        //             .on(device_exec);
+            auto trisolve_factory =
+                ir::build()
+                    .with_solver(share(
+                        bj::build().with_max_block_size(1).on(device_exec)))
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(5).on(
+                            device_exec))
+                    .on(device_exec);
 
-        //     // Use incomplete factors to generate ILU preconditioner auto
-        //     return
-        //     gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
-        // }
-        // if (name == "IRILU") {
-        //     auto factorizaton_factory =
-        //         gko::factorization::Ilu<scalar, label>::build()
-        //             .with_skip_sorting(skip_sorting)
-        //             .on(device_exec);
+            // Generate an ILU preconditioner factory by setting lower and
+            // upper
+            // triangular solver - in this case the previously defined
+            // iterative
+            // refinement method.
+            auto ilu_pre_factory =
+                gko::preconditioner::Ilu<ir, ir>::build()
+                    .with_l_solver_factory(gko::clone(trisolve_factory))
+                    .with_u_solver_factory(gko::clone(trisolve_factory))
+                    .on(device_exec);
 
-        //     auto par_ilu =
-        //         gko::share(factorizaton_factory->generate(gkomatrix));
-
-        //     auto bj_factory =
-        //         bj::build().with_max_block_size(1).on(device_exec);
-
-        //     auto trisolve_factory =
-        //         ir::build()
-        //             .with_solver(share(bj_factory))
-        //             .with_criteria(
-        //                 gko::stop::Iteration::build().with_max_iters(5).on(
-        //                     device_exec))
-        //             .on(device_exec);
-
-        //     // Generate an ILU preconditioner factory by setting lower and
-        //     upper
-        //     // triangular solver - in this case the previously defined
-        //     iterative
-        //     // refinement method.
-        //     auto ilu_pre_factory =
-        //         gko::preconditioner::Ilu<ir, ir>::build()
-        //             .with_l_solver_factory(gko::clone(trisolve_factory))
-        //             .with_u_solver_factory(gko::clone(trisolve_factory))
-        //             .on(device_exec);
-
-        //     // Use incomplete factors to generate ILU preconditioner
-        //     return
-        //     gko::share(ilu_pre_factory->generate(gko::share(par_ilu)));
-        // }
+            // Use incomplete factors to generate ILU preconditioner
+            return gko::share(ilu_pre_factory->generate(gko::share(
+                gko::share(factorizaton_factory->generate(gkomatrix)))));
+        }
         if (name == "IC") {
             auto factorizaton_factory =
                 gko::factorization::Ic<scalar, label>::build()
@@ -193,85 +184,86 @@ public:
 
             return wrap_schwarz(gkomatrix, device_exec, pre_factory);
         }
-        // if (name == "Multigrid") {
-        //     using ir = gko::solver::Ir<scalar>;
-        //     using cg = gko::solver::Cg<scalar>;
-        //     using mg = gko::solver::Multigrid;
-        //     using bj = gko::preconditioner::Jacobi<scalar, label>;
-        //     using amgx_pgm = gko::multigrid::AmgxPgm<scalar, label>;
+        if (name == "Multigrid") {
+            using ir = gko::solver::Ir<scalar>;
+            using cg = gko::solver::Cg<scalar>;
+            using mg = gko::solver::Multigrid;
+            using bj = gko::preconditioner::Jacobi<scalar, label>;
+            using amgx_pgm = gko::multigrid::AmgxPgm<scalar, label>;
 
-        //     auto inner_solver_gen =
-        //         gko::share(bj::build().with_max_block_size(1u).on(device_exec));
+            auto inner_solver_gen =
+                gko::share(bj::build().with_max_block_size(1u).on(device_exec));
 
-        //     auto smoother_gen = gko::share(
-        //         ir::build()
-        //             .with_solver(inner_solver_gen)
-        //             .with_relaxation_factor(0.9)
-        //             .with_criteria(
-        //                 gko::stop::Iteration::build().with_max_iters(2u).on(
-        //                     device_exec))
-        //             .on(device_exec));
+            auto smoother_gen = gko::share(
+                ir::build()
+                    .with_solver(inner_solver_gen)
+                    .with_relaxation_factor(0.9)
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(2u).on(
+                            device_exec))
+                    .on(device_exec));
 
-        //     // Create MultigridLevel factory
-        //     auto mg_level_gen =
-        //         amgx_pgm::build().with_deterministic(true).on(device_exec);
+            // Create MultigridLevel factory
+            auto mg_level_gen =
+                amgx_pgm::build().with_deterministic(true).on(device_exec);
 
-        //     // Create CoarsestSolver factory
-        //     // std::shared_ptr<gko::LinOp> coarsest_gen;
-        //     // coarsest_gen =
-        //     //
-        //     (solverControls_.lookupOrDefault("PreconditionerMultigridUseIR",
-        //     //                                      word("IR")) == "IR")
-        //     //         ? gko::share(
-        //     //               ir::build()
-        //     //                   .with_solver(inner_solver_gen)
-        //     //                   .with_relaxation_factor(0.9)
-        //     //                   .with_criteria(gko::stop::Iteration::build()
-        //     //                                      .with_max_iters(4u)
-        //     //                                      .on(device_exec))
-        //     //                   .on(device_exec))
-        //     //         : gko::share(
-        //     //               cg::build()
-        //     //                   .with_criteria(gko::stop::Iteration::build()
-        //     //                                      .with_max_iters(4u)
-        //     //                                      .on(device_exec))
-        //     //                   .on(device_exec));
+            // Create CoarsestSolver factory
+            // std::shared_ptr<gko::LinOp> coarsest_gen;
+            // coarsest_gen =
+            //
+            // (solverControls_.lookupOrDefault("PreconditionerMultigridUseIR",
+            //                                      word("IR")) == "IR")
+            //         ? gko::share(
+            //               ir::build()
+            //                   .with_solver(inner_solver_gen)
+            //                   .with_relaxation_factor(0.9)
+            //                   .with_criteria(gko::stop::Iteration::build()
+            //                                      .with_max_iters(4u)
+            //                                      .on(device_exec))
+            //                   .on(device_exec))
+            //         : gko::share(
+            //               cg::build()
+            //                   .with_criteria(gko::stop::Iteration::build()
+            //                                      .with_max_iters(4u)
+            //                                      .on(device_exec))
+            //                   .on(device_exec));
 
-        //     auto coarsest_gen = gko::share(
-        //         cg::build()
-        //             .with_criteria(
-        //                 gko::stop::Iteration::build().with_max_iters(4u).on(
-        //                     device_exec))
-        //             .on(device_exec));
+            auto coarsest_gen = gko::share(
+                cg::build()
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(4u).on(
+                            device_exec))
+                    .on(device_exec));
 
-        //     // Create multigrid factory
-        //     label max_levels(controls.lookupOrDefault("MaxLevels",
-        //     label(9))); label min_coarse_rows(
-        //         controls.lookupOrDefault("MinCoarseRows", label(10)));
-        //     bool zeroGuess(controls.lookupOrDefault<Switch>("ZeroGuess",
-        //     true));
+            // Create multigrid factory
+            label max_levels(controls.lookupOrDefault("MaxLevels", label(9)));
+            label min_coarse_rows(
+                controls.lookupOrDefault("MinCoarseRows", label(10)));
+            bool zeroGuess(controls.lookupOrDefault<Switch>("ZeroGuess", true));
 
-        //     word msg = "Generate preconditioner " + name + " MaxLevels " +
-        //                std::to_string(max_levels) + " MinCoarseRows " +
-        //                std::to_string(min_coarse_rows) + " ZeroGuess " +
-        //                std::to_string(zeroGuess);
-        //     LOG_1(verbose_, msg)
+            word msg = "Generate preconditioner " + name + " MaxLevels " +
+                       std::to_string(max_levels) + " MinCoarseRows " +
+                       std::to_string(min_coarse_rows) + " ZeroGuess " +
+                       std::to_string(zeroGuess);
+            LOG_1(verbose_, msg)
 
-        //     auto pre_factory = gko::share(
-        //         mg::build()
-        //             .with_max_levels(max_levels)
-        //             .with_min_coarse_rows(min_coarse_rows)
-        //             .with_pre_smoother(smoother_gen)
-        //             .with_post_uses_pre(true)
-        //             .with_mg_level(gko::share(mg_level_gen))
-        //             .with_coarsest_solver(coarsest_gen)
-        //             .with_zero_guess(zeroGuess)
-        //             .with_criteria(
-        //                 gko::stop::Iteration::build().with_max_iters(1u).on(
-        //                     device_exec))
-        //             .on(device_exec));
-        //     return wrap_schwarz(gkomatrix, device_exec, pre_factory);
-        // }
+            auto pre_factory = gko::share(
+                mg::build()
+                    .with_max_levels(max_levels)
+                    .with_min_coarse_rows(min_coarse_rows)
+                    .with_pre_smoother(smoother_gen)
+                    .with_post_uses_pre(true)
+                    .with_mg_level(gko::share(
+                        amgx_pgm::build().with_deterministic(true).on(
+                            device_exec)))
+                    .with_coarsest_solver(coarsest_gen)
+                    .with_zero_guess(zeroGuess)
+                    .with_criteria(
+                        gko::stop::Iteration::build().with_max_iters(1u).on(
+                            device_exec))
+                    .on(device_exec));
+            return wrap_schwarz(gkomatrix, device_exec, pre_factory);
+        }
         return {};
     }
 

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -143,7 +143,7 @@ class StoppingCriterion {
             // TODO store colA vector
             auto comm = x->get_communicator();
 
-            gko::dim<2> local_size = x->get_local()->get_size();
+            gko::dim<2> local_size = x->get_local_vector()->get_size();
             gko::dim<2> global_size = x->get_size();
 
             auto Axref = gko::share(

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -136,9 +136,19 @@ public:
 
 
     solverPerformance solve_serial_impl(scalarField &psi,
-                                        const PersistentArray<scalar> &b,
+                                        const scalarField &source,
                                         solverPerformance &solverPerf) const
     {
+        PersistentArray<scalar> b{
+            const_cast<scalar *>(&source[0]),
+            this->fieldName() + "_rhs",
+            db_,
+            this->get_exec_handler(),
+            this->get_global_cell_index(),
+            verbose_,
+            solver_controls_.lookupOrDefault<Switch>("updateRHS", true),
+            false};
+
         PersistentArray<scalar> x{
             &psi[0],
             this->fieldName() + "_solution",
@@ -191,7 +201,7 @@ public:
     }
 
     solverPerformance solve_multi_gpu_impl(scalarField &psi,
-                                           const PersistentArray<scalar> &b,
+                                           const scalarField &source,
                                            solverPerformance &solverPerf) const
     {
         // build partition: uniform number of rows per rank
@@ -206,6 +216,16 @@ public:
                                                                gko::int64>(
                 ref_exec, rows_start, rows_end, *comm.get()));
 
+        PersistentVector<scalar> dist_b{
+            &source[0],
+            this->fieldName() + "_solution",
+            db_,
+            this->get_exec_handler(),
+            partition,
+            verbose_,
+            solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
+            false};
+
         PersistentVector<scalar> dist_x{
             &psi[0],
             this->fieldName() + "_solution",
@@ -216,12 +236,6 @@ public:
             solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
             false};
 
-
-        // SIMPLE_TIME(verbose_, gather_initGuess,
-        //             auto dense_x = x.get_dense_vec();)
-        SIMPLE_TIME(verbose_, gather_RHS, auto dense_b = b.get_dense_vec();)
-
-
         scalar scaling =
             solver_controls_.lookupOrDefault<scalar>("scaling", 1.0);
         if (scaling != 1) {
@@ -230,7 +244,7 @@ public:
                     {scaling}, ref_exec));
 
             SIMPLE_TIME(verbose_, scale_RHS,
-                        dense_b->scale(dense_scaling.get());)
+                        dist_b.get_vector()->scale(dense_scaling.get());)
         }
 
         SIMPLE_TIME(verbose_, gather_global_matrix,
@@ -251,11 +265,6 @@ public:
         }
 
         auto device_exec = this->get_exec_handler().get_device_exec();
-        auto dist_b = gko::share(dist_vec::from_local<label, gko::int64>(
-            device_exec, *comm.get(), *b.get_array().get(), partition.get()));
-        // auto dist_x = gko::share(dist_vec::from_local<label, gko::int64>(
-        //     device_exec, *comm.get(), *x.get_array().get(),
-        //     partition.get()));
 
         auto A_host = gko::share(dist_mtx::create(ref_exec, *comm.get()));
         A_host->read_distributed(A_data, partition.get());
@@ -272,7 +281,7 @@ public:
         LOG_1(verbose_, "create solver")
         auto solver_gen = this->create_dist_solver(
             this->get_exec_handler().get_device_exec(), dist_A,
-            dist_x.get_vector(), dist_b, verbose_,
+            dist_x.get_vector(), dist_b.get_vector(), verbose_,
             csr_matrix_wrapper_.get_export(), precond);
 
         /* auto solver_gen = gko::share( */
@@ -288,12 +297,12 @@ public:
         SIMPLE_TIME(verbose_, generate_solver,
                     auto solver = solver_gen->generate(dist_A);)
         LOG_1(verbose_, "solve solver done")
-        SIMPLE_TIME(
-            verbose_, solve,
-            solver->apply(gko::lend(dist_b), gko::lend(dist_x.get_vector()));)
+        SIMPLE_TIME(verbose_, solve,
+                    solver->apply(gko::lend(dist_b.get_vector()),
+                                  gko::lend(dist_x.get_vector()));)
 
 
-        dist_x.copy_back();
+        SIMPLE_TIME(verbose_, copy_x_back, dist_x.copy_back();)
 
         solverPerf.initialResidual() = this->get_init_res_norm();
         solverPerf.finalResidual() = this->get_res_norm();
@@ -313,22 +322,11 @@ public:
                 this->get_exec_handler().get_exec_name() + typeName,
             this->fieldName());
 
-        PersistentArray<scalar> b{
-            const_cast<scalar *>(&source[0]),
-            this->fieldName() + "_rhs",
-            db_,
-            this->get_exec_handler(),
-            this->get_global_cell_index(),
-            verbose_,
-            solver_controls_.lookupOrDefault<Switch>("updateRHS", true),
-            false};
-
-
         // Solve system
         if (Pstream::parRun()) {
-            return solve_multi_gpu_impl(psi, b, solverPerf);
+            return solve_multi_gpu_impl(psi, source, solverPerf);
         } else {
-            return solve_serial_impl(psi, b, solverPerf);
+            return solve_serial_impl(psi, source, solverPerf);
         }
 
         return solverPerf;

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -218,12 +218,12 @@ public:
 
         PersistentVector<scalar> dist_b{
             &source[0],
-            this->fieldName() + "_solution",
+            this->fieldName() + "_rhs",
             db_,
             this->get_exec_handler(),
             partition,
             verbose_,
-            solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
+            solver_controls_.lookupOrDefault<Switch>("updateRHS", true),
             false};
 
         PersistentVector<scalar> dist_x{

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -136,10 +136,19 @@ public:
 
 
     solverPerformance solve_serial_impl(scalarField &psi,
-                                        PersistentArray<scalar> &x,
                                         const PersistentArray<scalar> &b,
                                         solverPerformance &solverPerf) const
     {
+        PersistentArray<scalar> x{
+            &psi[0],
+            this->fieldName() + "_solution",
+            db_,
+            this->get_exec_handler(),
+            this->get_global_cell_index(),
+            verbose_,
+            solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
+            false};
+
         auto ref_exec = this->get_exec_handler().get_ref_exec();
         LOG_1(verbose_, "get_gkomatrix")
         auto gkomatrix = csr_matrix_wrapper_.get_local_gkomatrix();
@@ -182,15 +191,36 @@ public:
     }
 
     solverPerformance solve_multi_gpu_impl(scalarField &psi,
-                                           PersistentArray<scalar> &x,
                                            const PersistentArray<scalar> &b,
                                            solverPerformance &solverPerf) const
     {
-        SIMPLE_TIME(verbose_, gather_initGuess,
-                    auto dense_x = x.get_dense_vec();)
-        SIMPLE_TIME(verbose_, gather_RHS, auto dense_b = b.get_dense_vec();)
+        // build partition: uniform number of rows per rank
+        auto comm = this->get_exec_handler().get_gko_mpi_comm_wrapper();
+        auto rows_start =
+            this->get_global_cell_index().offset(Pstream::myProcNo());
+        auto rows_end = rows_start + psi.size();
 
         auto ref_exec = this->get_exec_handler().get_ref_exec();
+        auto partition = gko::share(
+            gko::distributed::build_partition_from_local_range<label,
+                                                               gko::int64>(
+                ref_exec, rows_start, rows_end, *comm.get()));
+
+        PersistentVector<scalar> dist_x{
+            &psi[0],
+            this->fieldName() + "_solution",
+            db_,
+            this->get_exec_handler(),
+            partition,
+            verbose_,
+            solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
+            false};
+
+
+        // SIMPLE_TIME(verbose_, gather_initGuess,
+        //             auto dense_x = x.get_dense_vec();)
+        SIMPLE_TIME(verbose_, gather_RHS, auto dense_b = b.get_dense_vec();)
+
 
         scalar scaling =
             solver_controls_.lookupOrDefault<scalar>("scaling", 1.0);
@@ -205,16 +235,6 @@ public:
 
         SIMPLE_TIME(verbose_, gather_global_matrix,
                     auto gkomatrix = csr_matrix_wrapper_.get_local_gkomatrix();)
-
-        // build partition: uniform number of rows per rank
-        auto comm = this->get_exec_handler().get_gko_mpi_comm_wrapper();
-        auto rows_start =
-            this->get_global_cell_index().offset(Pstream::myProcNo());
-        auto rows_end = rows_start + psi.size();
-        auto partition = gko::share(
-            gko::distributed::build_partition_from_local_range<label,
-                                                               gko::int64>(
-                ref_exec, rows_start, rows_end, *comm.get()));
 
 
         gko::matrix_data<scalar, label> A_data_32;
@@ -233,8 +253,9 @@ public:
         auto device_exec = this->get_exec_handler().get_device_exec();
         auto dist_b = gko::share(dist_vec::from_local<label, gko::int64>(
             device_exec, *comm.get(), *b.get_array().get(), partition.get()));
-        auto dist_x = gko::share(dist_vec::from_local<label, gko::int64>(
-            device_exec, *comm.get(), *x.get_array().get(), partition.get()));
+        // auto dist_x = gko::share(dist_vec::from_local<label, gko::int64>(
+        //     device_exec, *comm.get(), *x.get_array().get(),
+        //     partition.get()));
 
         auto A_host = gko::share(dist_mtx::create(ref_exec, *comm.get()));
         A_host->read_distributed(A_data, partition.get());
@@ -250,8 +271,9 @@ public:
 
         LOG_1(verbose_, "create solver")
         auto solver_gen = this->create_dist_solver(
-            this->get_exec_handler().get_device_exec(), dist_A, dist_x, dist_b,
-            verbose_, csr_matrix_wrapper_.get_export(), precond);
+            this->get_exec_handler().get_device_exec(), dist_A,
+            dist_x.get_vector(), dist_b, verbose_,
+            csr_matrix_wrapper_.get_export(), precond);
 
         /* auto solver_gen = gko::share( */
         /*     gko::solver::Cg<scalar>::build() */
@@ -266,11 +288,12 @@ public:
         SIMPLE_TIME(verbose_, generate_solver,
                     auto solver = solver_gen->generate(dist_A);)
         LOG_1(verbose_, "solve solver done")
-        SIMPLE_TIME(verbose_, solve,
-                    solver->apply(gko::lend(dist_b), gko::lend(dist_x));)
+        SIMPLE_TIME(
+            verbose_, solve,
+            solver->apply(gko::lend(dist_b), gko::lend(dist_x.get_vector()));)
 
 
-        x.copy_back(dist_x);
+        dist_x.copy_back();
 
         solverPerf.initialResidual() = this->get_init_res_norm();
         solverPerf.finalResidual() = this->get_res_norm();
@@ -284,9 +307,6 @@ public:
                                   const scalarField &source,
                                   const direction cmpt = 0) const
     {
-        std::shared_ptr<gko::Executor> device_exec =
-            this->get_exec_handler().get_device_exec();
-
         // --- Setup class containing solver performance data
         solverPerformance solverPerf(
             lduMatrix::preconditioner::getName(this->controlDict_) +
@@ -303,53 +323,12 @@ public:
             solver_controls_.lookupOrDefault<Switch>("updateRHS", true),
             false};
 
-        PersistentArray<scalar> x{
-            &psi[0],
-            this->fieldName() + "_solution",
-            db_,
-            this->get_exec_handler(),
-            this->get_global_cell_index(),
-            verbose_,
-            solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
-            false};
 
         // Solve system
         if (Pstream::parRun()) {
-            return solve_multi_gpu_impl(psi, x, b, solverPerf);
-            // SIMPLE_TIME(verbose_, retrieve_result_from_device,
-            //             dense_x->copy_back_host(&psi[0], x_host);)
-
-
-            //     if (Pstream::master()) {
-            //         LOG_1(verbose_, "create solver factory")
-
-
-            //         auto solver_gen = this->create_solver(
-            //             this->get_exec_handler().get_device_exec(),
-            //             gkomatrix.get_persistent_object(), dense_x,
-            //             dense_b, verbose_,
-            //             csr_matrix_wrapper_.get_export(), precond);
-            //         LOG_1(verbose_, "create solver")
-            //         SIMPLE_TIME(verbose_, generate_solver,
-            //                     auto solver = solver_gen->generate(
-            //                         gko::share(gkomatrix.get_persistent_object()));)
-            //         LOG_1(verbose_, "solve solver done")
-            //         SIMPLE_TIME(
-            //             verbose_, solve,
-            //             solver->apply(gko::lend(dense_b),
-            //             gko::lend(dense_x));)
-            //         LOG_1(verbose_, "copy back")
-            //         solverPerf.initialResidual() =
-            //         this->get_init_res_norm(); solverPerf.finalResidual()
-            //         = this->get_res_norm(); solverPerf.nIterations() =
-            //         this->get_number_of_iterations();
-            //         this->store_number_of_iterations();
-            //     }
-            //     SIMPLE_TIME(verbose_, retrieve_result_from_device,
-            //                 x.copy_back_parallel(this->get_global_cell_index(),
-            //                                      &psi[0], dense_x);)
+            return solve_multi_gpu_impl(psi, b, solverPerf);
         } else {
-            return solve_serial_impl(psi, x, b, solverPerf);
+            return solve_serial_impl(psi, b, solverPerf);
         }
 
         return solverPerf;

--- a/third_party/ginkgo/CMakeLists.txt
+++ b/third_party/ginkgo/CMakeLists.txt
@@ -2,7 +2,7 @@
 ginkgo_load_git_package(
   ginkgo_external
   "https://github.com/ginkgo-project/ginkgo.git"
-  "ogl_develop"
+  "ogl_develop_merge"
   "-DGINKGO_BUILD_CUDA=${GINKGO_BUILD_CUDA}"
   "-DGINKGO_BUILD_HIP=${GINKGO_BUILD_HIP}"
   "-DGINKGO_BUILD_OMP=${GINKGO_BUILD_OMP}"


### PR DESCRIPTION
This PR adds a device persistent version of `gko::distributed::vector` which fixes the issue of the initial guess not being updated. Furthermore, small adjustments were made to base OGL on most recent distributed ginkgo version.