### PR TITLE
Improve error message for wrong precond choice

### DIFF
--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -347,7 +347,8 @@ public:
             return {};
         }
 
-        FatalErrorInFunction << "Preconditioner " << name << " not supported "
+        FatalErrorInFunction << "OGL does not support the preconditioner: " << name 
+                             << "\nValid Choices: none, BJ, ILU, ISAI, IC, Multigrid" 
                              << abort(FatalError);
         return {};
     }

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -347,9 +347,10 @@ public:
             return {};
         }
 
-        FatalErrorInFunction << "OGL does not support the preconditioner: " << name 
-                             << "\nValid Choices: none, BJ, ILU, ISAI, IC, Multigrid" 
-                             << abort(FatalError);
+        FatalErrorInFunction
+            << "OGL does not support the preconditioner: " << name
+            << "\nValid Choices: none, BJ, ILU, ISAI, IC, Multigrid"
+            << abort(FatalError);
         return {};
     }
 


### PR DESCRIPTION
This PR adds a clearer error message for unsupported preconditioner choices by printing out valid preconditioner.