### PR TITLE
Improve backend stability

### DIFF
--- a/.github/workflows/build-foam.yml
+++ b/.github/workflows/build-foam.yml
@@ -92,7 +92,7 @@ jobs:
         cp -r /github/home/libbin/libginkgo* $FOAM_USER_LIBBIN
         cp -r /github/home/libbin/cmake $FOAM_USER_LIBBIN
         cp -r /github/home/libbin/pkgconfig $FOAM_USER_LIBBIN
-        cmake -G Ninja -DOGL_DATA_VALIDATION=On -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake -G Ninja -DOGL_DATA_VALIDATION=On -DOGL_ALLOW_REFERENCE_ONLY=On -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 
     - name: Build OGL
       working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,19 @@ option(OGL_USE_FOAM_FOUNDATION_VERSION
        "Build OGL for the OpenFOAM Foundation version" FALSE)
 option(GINKGO_BUILD_CUDA "Build Ginkgo with cuda backend" FALSE)
 option(GINKGO_BUILD_HIP "Build Ginkgo with hip backend" FALSE)
+option(GINKGO_BUILD_SYCL "Build Ginkgo with sycl backend" FALSE)
 option(GINKGO_BUILD_OMP "Build Ginkgo with omp backend" FALSE)
 option(GINKGO_BUILD_REFERENCE "Build Ginkgo with reference backend" TRUE)
+option(OGL_ALLOW_REFERENCE_ONLY "Enable builds of Ginkgo with reference backend only" FALSE)
 option(GINKGO_FORCE_GPU_AWARE_MPI "Build Ginkgo using device aware MPI" TRUE)
 option(GINKGO_WITH_OGL_EXTENSIONS "Whether ginkgo was build with OGL extension"
        FALSE)
+
+if(NOT OGL_ALLOW_REFERENCE_ONLY)
+    if ((NOT GINKGO_BUILD_CUDA) AND (NOT GINKGO_BUILD_HIP) AND (NOT GINKGO_BUILD_SYCL))
+        message(FATAL_ERROR "No GPU Backend was selected, set either:\n -DGINGKO_BUILD_CUDA=True\n -DGINGKO_BUILD_HIP=True\n -DGINGKO_BUILD_SYCL=True\n or set:\n -DOGL_ALLOW_REFERENCE_ONLY=True\n to turn off this check")
+    endif()
+endif()
 
 set(GINKGO_CHECKOUT_VERSION
     "4292ffdee"

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -69,9 +69,11 @@ struct ExecutorInitFunctor {
         auto host_exec = gko::share(gko::ReferenceExecutor::create());
 
         if (executor_name_ == "cuda") {
-            if (version.cuda_version.tag == not_compiled_tag){
-            FatalErrorInFunction << "CUDA Backend was not compiled. Recompile OGL/Ginkgo with CUDA backend enabled."
-                                 << abort(FatalError);
+            if (version.cuda_version.tag == not_compiled_tag) {
+                FatalErrorInFunction
+                    << "CUDA Backend was not compiled. Recompile OGL/Ginkgo "
+                       "with CUDA backend enabled."
+                    << abort(FatalError);
             };
 
             return gko::share(gko::CudaExecutor::create(
@@ -79,18 +81,22 @@ struct ExecutorInitFunctor {
                 false, gko::allocation_mode::device));
         }
         if (executor_name_ == "dpcpp") {
-            if (version.dpcpp_version.tag == not_compiled_tag){
-            FatalErrorInFunction << "SYCL Backend was not compiled. Recompile OGL/Ginkgo with SYCL backend enabled."
-                                 << abort(FatalError);
+            if (version.dpcpp_version.tag == not_compiled_tag) {
+                FatalErrorInFunction
+                    << "SYCL Backend was not compiled. Recompile OGL/Ginkgo "
+                       "with SYCL backend enabled."
+                    << abort(FatalError);
             };
             return gko::share(gko::DpcppExecutor::create(
                 device_id_ % gko::DpcppExecutor::get_num_devices("gpu"),
                 host_exec));
         }
         if (executor_name_ == "hip") {
-            if (version.hip_version.tag == not_compiled_tag){
-            FatalErrorInFunction << "HIP Backend was not compiled. Recompile OGL/Ginkgo with HIP backend enabled."
-                                 << abort(FatalError);
+            if (version.hip_version.tag == not_compiled_tag) {
+                FatalErrorInFunction
+                    << "HIP Backend was not compiled. Recompile OGL/Ginkgo "
+                       "with HIP backend enabled."
+                    << abort(FatalError);
             };
 
             return gko::share(gko::HipExecutor::create(
@@ -98,9 +104,11 @@ struct ExecutorInitFunctor {
                 true));
         }
         if (executor_name_ == "omp") {
-            if (version.omp_version.tag == not_compiled_tag){
-            FatalErrorInFunction << "OMP Backend was not compiled. Recompile OGL/Ginkgo with OMP backend enabled."
-                                 << abort(FatalError);
+            if (version.omp_version.tag == not_compiled_tag) {
+                FatalErrorInFunction
+                    << "OMP Backend was not compiled. Recompile OGL/Ginkgo "
+                       "with OMP backend enabled."
+                    << abort(FatalError);
             }
             return gko::share(gko::OmpExecutor::create());
         }

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -62,26 +62,46 @@ struct ExecutorInitFunctor {
 
     void update(std::shared_ptr<gko::Executor>) const {}
 
+    const std::string not_compiled_tag = "not compiled";
+    const gko::version_info version = gko::version_info::get();
     std::shared_ptr<gko::Executor> init() const
     {
         auto host_exec = gko::share(gko::ReferenceExecutor::create());
 
         if (executor_name_ == "cuda") {
+            if (version.cuda_version.tag == not_compiled_tag){
+            FatalErrorInFunction << "CUDA Backend was not compiled. Recompile OGL/Ginkgo with CUDA backend enabled."
+                                 << abort(FatalError);
+            };
+
             return gko::share(gko::CudaExecutor::create(
                 device_id_ % gko::CudaExecutor::get_num_devices(), host_exec,
                 false, gko::allocation_mode::device));
         }
         if (executor_name_ == "dpcpp") {
+            if (version.dpcpp_version.tag == not_compiled_tag){
+            FatalErrorInFunction << "SYCL Backend was not compiled. Recompile OGL/Ginkgo with SYCL backend enabled."
+                                 << abort(FatalError);
+            };
             return gko::share(gko::DpcppExecutor::create(
                 device_id_ % gko::DpcppExecutor::get_num_devices("gpu"),
                 host_exec));
         }
         if (executor_name_ == "hip") {
+            if (version.hip_version.tag == not_compiled_tag){
+            FatalErrorInFunction << "HIP Backend was not compiled. Recompile OGL/Ginkgo with HIP backend enabled."
+                                 << abort(FatalError);
+            };
+
             return gko::share(gko::HipExecutor::create(
                 device_id_ % gko::HipExecutor::get_num_devices(), host_exec,
                 true));
         }
         if (executor_name_ == "omp") {
+            if (version.omp_version.tag == not_compiled_tag){
+            FatalErrorInFunction << "OMP Backend was not compiled. Recompile OGL/Ginkgo with OMP backend enabled."
+                                 << abort(FatalError);
+            }
             return gko::share(gko::OmpExecutor::create());
         }
         if (executor_name_ == "reference") {


### PR DESCRIPTION
This PR addresses #83 by allowing builds with only the reference backend if `-DOGL_ALLOW_REFERENCE_ONLY=On` is set and throws an error if a backend is selected at run time which was not compiled.