### PR TITLE
Fix processor interface coeffs

### DIFF
--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -71,13 +71,13 @@ std::vector<scalar> HostMatrixWrapper<MatrixType>::collect_interface_coeffs(
         }
         const auto iface{interfaces.operator()(i)};
         auto coeffs{interfaceBouCoeffs[i]};
-        const label interface_size = face_cells.size();
 
         bool collect = (local)
-                           ? !!isA<processorLduInterface>(iface->interface())
-                           : !isA<processorLduInterface>(iface->interface());
+                           ?!isA<processorLduInterface>(iface->interface())
+                           :!!isA<processorLduInterface>(iface->interface());
 
         if (collect) {
+            const label interface_size = iface->interface().faceCells().size();
             for (label cellI = 0; cellI < interface_size; cellI++) {
                 ret.push_back(coeffs[cellI]);
             }

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -73,8 +73,8 @@ std::vector<scalar> HostMatrixWrapper<MatrixType>::collect_interface_coeffs(
         auto coeffs{interfaceBouCoeffs[i]};
 
         bool collect = (local)
-                           ?!isA<processorLduInterface>(iface->interface())
-                           :!!isA<processorLduInterface>(iface->interface());
+                           ? !isA<processorLduInterface>(iface->interface())
+                           : !!isA<processorLduInterface>(iface->interface());
 
         if (collect) {
             const label interface_size = iface->interface().faceCells().size();

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -290,12 +290,14 @@ public:
         // TODO reimplement this
     }
 
-    /* Iterates all interfaces and counts elements
+    /* Iterates all interfaces and collects the coefficients into a vector
     **
+    ** @param local whether local or non local coefficients should be collected
     */
-    std::vector<scalar> collect_local_interface_coeffs(
+    std::vector<scalar> collect_interface_coeffs(
         const lduInterfaceFieldPtrsList &interfaces_,
-        const FieldField<Field, scalar> &interfaceBouCoeffs) const;
+        const FieldField<Field, scalar> &interfaceBouCoeffs
+        const bool local) const;
 
 
     /* Iterates all local interfaces and returns the relative order and
@@ -315,13 +317,6 @@ public:
     */
     label count_interface_nnz(const lduInterfaceFieldPtrsList &interfaces,
                               bool proc_interfaces) const;
-
-    /* Collect the non local matrix coefficients
-    **
-    */
-    std::vector<scalar> communicate_non_local_coeffs(
-        const lduInterfaceFieldPtrsList &interfaces,
-        const FieldField<Field, scalar> &interfaceBouCoeffs) const;
 
     /* Iterates all interfaces and collects non-local global column indices
     **

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -296,7 +296,7 @@ public:
     */
     std::vector<scalar> collect_interface_coeffs(
         const lduInterfaceFieldPtrsList &interfaces_,
-        const FieldField<Field, scalar> &interfaceBouCoeffs
+        const FieldField<Field, scalar> &interfaceBouCoeffs,
         const bool local) const;
 
 

--- a/common/common.C
+++ b/common/common.C
@@ -55,6 +55,18 @@ void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
     export_x(fn_mtx, x);
 }
 
+void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
+                const word local, const objectRegistry &db)
+{
+    auto time_name = db_.time().timeName();
+    auto folder =
+        "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
+    system("mkdir -p " + folder);
+    std::string fn{folder + this->fieldName() + "_A_" + local ".mtx"};
+    std::ofstream stream{fn};
+    gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
+}
+
 void export_system(const word fieldName, const gko::matrix::Csr<scalar> *A,
                    const gko::matrix::Dense<scalar> *x,
                    const gko::matrix::Dense<scalar> *b, const word time)

--- a/common/common.C
+++ b/common/common.C
@@ -58,11 +58,11 @@ void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db)
 {
-    auto time_name = db_.time().timeName();
+    auto time_name = db.time().timeName();
     auto folder =
         "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
     system("mkdir -p " + folder);
-    std::string fn{folder + this->fieldName() + "_A_" + local ".mtx"};
+    std::string fn{folder + fieldName + "_A_" + local + ".mtx"};
     std::ofstream stream{fn};
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
 }

--- a/common/common.H
+++ b/common/common.H
@@ -117,7 +117,7 @@ void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
                 const word time);
 
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
-                const word local, const objectRegistry &db)
+                const word local, const objectRegistry &db);
 
 void set_solve_prev_iters(const word sys_matrix_name, const objectRegistry &db,
                           label prev_solve_iters, const bool is_final);

--- a/common/common.H
+++ b/common/common.H
@@ -116,6 +116,9 @@ void export_system(const word fieldName, const gko::matrix::Csr<scalar> *A,
 void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
                 const word time);
 
+void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
+                const word local, const objectRegistry &db)
+
 void set_solve_prev_iters(const word sys_matrix_name, const objectRegistry &db,
                           label prev_solve_iters, const bool is_final);
 

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -280,91 +280,95 @@ public:
 
 #ifdef DATA_VALIDATION
         // TODO improve this
-        if(db_.time().writeTime()) {
-
-            auto time_name = db_.time().timeName();
-            auto folder = "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/export";
-            system("mkdir -p " + folder );
-                std::string fn{ folder + this->fieldName() + "_A.mtx"};
-                std::ofstream stream_x{fn};
-                std::shared_ptr<const gko::LinOp> local_mtx =
-                    gko::as<gko::experimental::distributed::Matrix<scalar, label,
-                                                                label>>(dist_A_v)
-                        ->get_local_matrix();
-                gko::write(stream_x,
-                        (const gko::matrix::Coo<scalar> *)local_mtx.get());
-        }
+        if (db_.time().writeTime()) {
+            export_mtx(
+                this->fieldName(),
+                gko::as<gko::experimental::distributed::Matrix<scalar, label,
+                                                               label>>(dist_A_v)
+                    ->get_local_matrix(),
+                "local" db_)
+            export_mtx(
+                this->fieldName(),
+                gko::as<gko::experimental::distributed::Matrix<scalar, label,
+                                                               label>>(dist_A_v)
+                    ->get_non_local_matrix(),
+                "non_local" db_)
+                }
 #endif
 
 
-        LOG_1(verbose_, "create solver")
-        auto solver_gen = this->create_dist_solver(
-            this->get_exec_handler().get_device_exec(), dist_A_v, dist_x_v,
-            dist_b_v, verbose_, dist_A.get_export(), precond);
+                LOG_1(verbose_, "create solver") auto solver_gen =
+                    this->create_dist_solver(
+                        this->get_exec_handler().get_device_exec(), dist_A_v,
+                        dist_x_v, dist_b_v, verbose_, dist_A.get_export(),
+                        precond);
 
-        TIME_WITH_FIELDNAME(verbose_, generate_solver, this->fieldName(),
-                            auto solver = solver_gen->generate(dist_A_v);)
-        LOG_1(verbose_, "solve solver done")
-        TIME_WITH_FIELDNAME(
-            verbose_, solve, this->fieldName(),
-            solver->apply(gko::lend(dist_b_v), gko::lend(dist_x_v));)
-
-        TIME_WITH_FIELDNAME(verbose_, copy_x_back, this->fieldName(),
-                            dist_x.copy_back();)
-        auto bandwidth_copy_back = sizeof(scalar) *
-                                  partition.get_local_device_size() /
-                                  delta_t_copy_x_back / 1000.0;
-
-        solverPerf.initialResidual() = this->get_init_res_norm();
-        solverPerf.finalResidual() = this->get_res_norm();
-        solverPerf.nIterations() = this->get_number_of_iterations();
-        this->store_number_of_iterations();
-        auto time_for_res_norm_eval = this->get_res_norm_time();
-        auto time_per_iter = delta_t_solve / this->get_number_of_iterations();
-        scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
-        this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
-            this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1, 0);
-        this->set_prev_rel_res_cost(prev_rel_res_cost);
-        auto time_per_iter_and_dof =
-            time_per_iter * 1000.0 / partition.get_total_size();
-        word msg =
-            "\nStatistics:\n\tTime per iteration: " +
-            std::to_string(time_per_iter) +
-            std::string(" [mu s]\n\tTime per residual norm calculation: ") +
-            std::to_string(time_for_res_norm_eval) +
-            std::string(" [mu s]\n\tTime per iteration and DOF: ") +
-            std::to_string(time_per_iter_and_dof) + std::string(" [ns]") +
-            std::string("\n\tRetrieve results bandwidth ") +
-            std::to_string(bandwidth_copy_back) + std::string(" [GByte/s]");
-        MLOG_0(verbose_, msg)
-
-        return solverPerf;
-    }
-
-    solverPerformance solve_impl_(word typeName, scalarField &psi,
-                                  const scalarField &source,
-                                  const direction cmpt = 0) const
-    {
-        // --- Setup class containing solver performance data
-        solverPerformance solverPerf(
-            lduMatrix::preconditioner::getName(this->controlDict_) +
-                this->get_exec_handler().get_exec_name() + typeName,
-            this->fieldName());
-
-        // Solve system
-        if (Pstream::parRun()) {
+            TIME_WITH_FIELDNAME(verbose_, generate_solver, this->fieldName(),
+                                auto solver = solver_gen->generate(dist_A_v);)
+            LOG_1(verbose_, "solve solver done")
             TIME_WITH_FIELDNAME(
-                verbose_, solve_multi_gpu, this->fieldName(),
-                auto res = solve_multi_gpu_impl(psi, source, solverPerf);)
-            return res;
-        } else {
-            FatalErrorInFunction << "Only parallel runs are supported for OGL"
-                                 << exit(FatalError);
+                verbose_, solve, this->fieldName(),
+                solver->apply(gko::lend(dist_b_v), gko::lend(dist_x_v));)
+
+            TIME_WITH_FIELDNAME(verbose_, copy_x_back, this->fieldName(),
+                                dist_x.copy_back();)
+            auto bandwidth_copy_back = sizeof(scalar) *
+                                       partition.get_local_device_size() /
+                                       delta_t_copy_x_back / 1000.0;
+
+            solverPerf.initialResidual() = this->get_init_res_norm();
+            solverPerf.finalResidual() = this->get_res_norm();
+            solverPerf.nIterations() = this->get_number_of_iterations();
+            this->store_number_of_iterations();
+            auto time_for_res_norm_eval = this->get_res_norm_time();
+            auto time_per_iter =
+                delta_t_solve / this->get_number_of_iterations();
+            scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
+            this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
+                this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1,
+                0);
+            this->set_prev_rel_res_cost(prev_rel_res_cost);
+            auto time_per_iter_and_dof =
+                time_per_iter * 1000.0 / partition.get_total_size();
+            word msg =
+                "\nStatistics:\n\tTime per iteration: " +
+                std::to_string(time_per_iter) +
+                std::string(" [mu s]\n\tTime per residual norm calculation: ") +
+                std::to_string(time_for_res_norm_eval) +
+                std::string(" [mu s]\n\tTime per iteration and DOF: ") +
+                std::to_string(time_per_iter_and_dof) + std::string(" [ns]") +
+                std::string("\n\tRetrieve results bandwidth ") +
+                std::to_string(bandwidth_copy_back) + std::string(" [GByte/s]");
+            MLOG_0(verbose_, msg)
+
+            return solverPerf;
         }
 
-        return solverPerf;
+        solverPerformance solve_impl_(word typeName, scalarField & psi,
+                                      const scalarField &source,
+                                      const direction cmpt = 0) const
+        {
+            // --- Setup class containing solver performance data
+            solverPerformance solverPerf(
+                lduMatrix::preconditioner::getName(this->controlDict_) +
+                    this->get_exec_handler().get_exec_name() + typeName,
+                this->fieldName());
+
+            // Solve system
+            if (Pstream::parRun()) {
+                TIME_WITH_FIELDNAME(
+                    verbose_, solve_multi_gpu, this->fieldName(),
+                    auto res = solve_multi_gpu_impl(psi, source, solverPerf);)
+                return res;
+            } else {
+                FatalErrorInFunction
+                    << "Only parallel runs are supported for OGL"
+                    << exit(FatalError);
+            }
+
+            return solverPerf;
+        };
     };
-};
 }  // namespace Foam
 
 #endif

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -286,89 +286,85 @@ public:
                 gko::as<gko::experimental::distributed::Matrix<scalar, label,
                                                                label>>(dist_A_v)
                     ->get_local_matrix(),
-                "local" db_)
+                "local", db_);
             export_mtx(
                 this->fieldName(),
                 gko::as<gko::experimental::distributed::Matrix<scalar, label,
                                                                label>>(dist_A_v)
                     ->get_non_local_matrix(),
-                "non_local" db_)
-                }
+                "non_local", db_);
+        }
 #endif
 
 
-                LOG_1(verbose_, "create solver") auto solver_gen =
-                    this->create_dist_solver(
-                        this->get_exec_handler().get_device_exec(), dist_A_v,
-                        dist_x_v, dist_b_v, verbose_, dist_A.get_export(),
-                        precond);
+        LOG_1(verbose_, "create solver")
+        auto solver_gen = this->create_dist_solver(
+            this->get_exec_handler().get_device_exec(), dist_A_v, dist_x_v,
+            dist_b_v, verbose_, dist_A.get_export(), precond);
 
-            TIME_WITH_FIELDNAME(verbose_, generate_solver, this->fieldName(),
-                                auto solver = solver_gen->generate(dist_A_v);)
-            LOG_1(verbose_, "solve solver done")
+        TIME_WITH_FIELDNAME(verbose_, generate_solver, this->fieldName(),
+                            auto solver = solver_gen->generate(dist_A_v);)
+        LOG_1(verbose_, "solve solver done")
+        TIME_WITH_FIELDNAME(
+            verbose_, solve, this->fieldName(),
+            solver->apply(gko::lend(dist_b_v), gko::lend(dist_x_v));)
+
+        TIME_WITH_FIELDNAME(verbose_, copy_x_back, this->fieldName(),
+                            dist_x.copy_back();)
+        auto bandwidth_copy_back = sizeof(scalar) *
+                                   partition.get_local_device_size() /
+                                   delta_t_copy_x_back / 1000.0;
+
+        solverPerf.initialResidual() = this->get_init_res_norm();
+        solverPerf.finalResidual() = this->get_res_norm();
+        solverPerf.nIterations() = this->get_number_of_iterations();
+        this->store_number_of_iterations();
+        auto time_for_res_norm_eval = this->get_res_norm_time();
+        auto time_per_iter = delta_t_solve / this->get_number_of_iterations();
+        scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
+        this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
+            this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1, 0);
+        this->set_prev_rel_res_cost(prev_rel_res_cost);
+        auto time_per_iter_and_dof =
+            time_per_iter * 1000.0 / partition.get_total_size();
+        word msg =
+            "\nStatistics:\n\tTime per iteration: " +
+            std::to_string(time_per_iter) +
+            std::string(" [mu s]\n\tTime per residual norm calculation: ") +
+            std::to_string(time_for_res_norm_eval) +
+            std::string(" [mu s]\n\tTime per iteration and DOF: ") +
+            std::to_string(time_per_iter_and_dof) + std::string(" [ns]") +
+            std::string("\n\tRetrieve results bandwidth ") +
+            std::to_string(bandwidth_copy_back) + std::string(" [GByte/s]");
+        MLOG_0(verbose_, msg)
+
+        return solverPerf;
+    }
+
+    solverPerformance solve_impl_(word typeName, scalarField &psi,
+                                  const scalarField &source,
+                                  const direction cmpt = 0) const
+    {
+        // --- Setup class containing solver performance data
+        solverPerformance solverPerf(
+            lduMatrix::preconditioner::getName(this->controlDict_) +
+                this->get_exec_handler().get_exec_name() + typeName,
+            this->fieldName());
+
+        // Solve system
+        if (Pstream::parRun()) {
             TIME_WITH_FIELDNAME(
-                verbose_, solve, this->fieldName(),
-                solver->apply(gko::lend(dist_b_v), gko::lend(dist_x_v));)
-
-            TIME_WITH_FIELDNAME(verbose_, copy_x_back, this->fieldName(),
-                                dist_x.copy_back();)
-            auto bandwidth_copy_back = sizeof(scalar) *
-                                       partition.get_local_device_size() /
-                                       delta_t_copy_x_back / 1000.0;
-
-            solverPerf.initialResidual() = this->get_init_res_norm();
-            solverPerf.finalResidual() = this->get_res_norm();
-            solverPerf.nIterations() = this->get_number_of_iterations();
-            this->store_number_of_iterations();
-            auto time_for_res_norm_eval = this->get_res_norm_time();
-            auto time_per_iter =
-                delta_t_solve / this->get_number_of_iterations();
-            scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
-            this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
-                this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1,
-                0);
-            this->set_prev_rel_res_cost(prev_rel_res_cost);
-            auto time_per_iter_and_dof =
-                time_per_iter * 1000.0 / partition.get_total_size();
-            word msg =
-                "\nStatistics:\n\tTime per iteration: " +
-                std::to_string(time_per_iter) +
-                std::string(" [mu s]\n\tTime per residual norm calculation: ") +
-                std::to_string(time_for_res_norm_eval) +
-                std::string(" [mu s]\n\tTime per iteration and DOF: ") +
-                std::to_string(time_per_iter_and_dof) + std::string(" [ns]") +
-                std::string("\n\tRetrieve results bandwidth ") +
-                std::to_string(bandwidth_copy_back) + std::string(" [GByte/s]");
-            MLOG_0(verbose_, msg)
-
-            return solverPerf;
+                verbose_, solve_multi_gpu, this->fieldName(),
+                auto res = solve_multi_gpu_impl(psi, source, solverPerf);)
+            return res;
+        } else {
+            FatalErrorInFunction << "Only parallel runs are supported for OGL"
+                                 << exit(FatalError);
         }
 
-        solverPerformance solve_impl_(word typeName, scalarField & psi,
-                                      const scalarField &source,
-                                      const direction cmpt = 0) const
-        {
-            // --- Setup class containing solver performance data
-            solverPerformance solverPerf(
-                lduMatrix::preconditioner::getName(this->controlDict_) +
-                    this->get_exec_handler().get_exec_name() + typeName,
-                this->fieldName());
-
-            // Solve system
-            if (Pstream::parRun()) {
-                TIME_WITH_FIELDNAME(
-                    verbose_, solve_multi_gpu, this->fieldName(),
-                    auto res = solve_multi_gpu_impl(psi, source, solverPerf);)
-                return res;
-            } else {
-                FatalErrorInFunction
-                    << "Only parallel runs are supported for OGL"
-                    << exit(FatalError);
-            }
-
-            return solverPerf;
-        };
+        return solverPerf;
     };
+};
 }  // namespace Foam
 
 #endif

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -280,15 +280,19 @@ public:
 
 #ifdef DATA_VALIDATION
         // TODO improve this
-        if (Pstream::myProcNo() == 0) {
-            std::string fn{this->fieldName() + "_A.mtx"};
-            std::ofstream stream_x{fn};
-            std::shared_ptr<const gko::LinOp> local_mtx =
-                gko::as<gko::experimental::distributed::Matrix<scalar, label,
-                                                               label>>(dist_A_v)
-                    ->get_local_matrix();
-            gko::write(stream_x,
-                       (const gko::matrix::Coo<scalar> *)local_mtx.get());
+        if(db_.time().writeTime()) {
+
+            auto time_name = db_.time().timeName();
+            auto folder = "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/export";
+            system("mkdir -p " + folder );
+                std::string fn{ folder + this->fieldName() + "_A.mtx"};
+                std::ofstream stream_x{fn};
+                std::shared_ptr<const gko::LinOp> local_mtx =
+                    gko::as<gko::experimental::distributed::Matrix<scalar, label,
+                                                                label>>(dist_A_v)
+                        ->get_local_matrix();
+                gko::write(stream_x,
+                        (const gko::matrix::Coo<scalar> *)local_mtx.get());
         }
 #endif
 

--- a/test/channel.yaml
+++ b/test/channel.yaml
@@ -7,7 +7,8 @@ case:
       - controlDict:
            writeFormat: binary
            libs: ["libOGL.so"]
-           writeInterval: 400
+           writeInterval: 100
+           endTime: 200
       - blockMesh
       - decomposePar:
             method: simple


### PR DESCRIPTION
This PR fixes the issue that for non local interfaces the coefficients are unnecessarily communicated before assembling the matrix coefficients. Additionally, exporting the distributed matrix is implemented.