### PR TITLE
Fix failure for zero iteration solver calls

### DIFF
--- a/.github/workflows/build-foam.yml
+++ b/.github/workflows/build-foam.yml
@@ -84,12 +84,18 @@ jobs:
         echo "FOAM_SRC=$FOAM_INST_DIR/${{matrix.OF.path}}/src"     >> $GITHUB_ENV
         echo "Ginkgo_DIR=${{env.FOAM_INST_DIR}}/root-${{matrix.OF.version}}/platforms/linux64GccDPInt32Opt/lib/cmake/Ginkgo" >> $GITHUB_ENV
 
-    - name: Cache build
+    - name: Cache build folder
       uses: actions/cache@v3
       with:
         key: build-${{ matrix.OF.path }}-${{env.GINKGO_CHECKOUT_VERSION}}
         path: |
           ${{github.workspace}}/build
+
+    - name: Cache FOAM_USER_LIBBIN
+      uses: actions/cache@v3
+      with:
+        key: FOAM_USER_LIBBIN-${{ matrix.OF.path }}-${{ github.sha }}
+        path: |
           ${{env.FOAM_USER_LIBBIN}}
 
     - name: Configure CMake

--- a/.github/workflows/build-foam.yml
+++ b/.github/workflows/build-foam.yml
@@ -105,7 +105,7 @@ jobs:
         #[ -f "/github/home/libbin/libginkgo.so" ] && cp -rp /github/home/libbin/libginkgo* $FOAM_USER_LIBBIN
         #[ -d "/github/home/libbin/cmake" ] && cp -rp /github/home/libbin/cmake $FOAM_USER_LIBBIN
         #[ -d "/github/home/libbin/pkgconfig" ] && cp -rp /github/home/libbin/pkgconfig $FOAM_USER_LIBBIN
-        cmake -G Ninja -DOGL_DATA_VALIDATION=On -DOGL_ALLOW_REFERENCE_ONLY=On -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake -G Ninja -DOGL_ALLOW_REFERENCE_ONLY=On -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 
     - name: Build OGL
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-foam.yml
+++ b/.github/workflows/build-foam.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Cache FOAM_USER_LIBBIN
       uses: actions/cache@v3
       with:
-        key: FOAM_USER_LIBBIN-${{ matrix.OF.path }}-${{ github.sha }}
+        key: FOAM_USER_LIBBIN-${{ matrix.OF.version }}-${{ github.sha }}
         path: |
           ${{env.FOAM_USER_LIBBIN}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,7 +174,7 @@ jobs:
       working-directory: /github/home/${{matrix.Case}}
       shell: bash
       run: |
-        python3 /__w/OGL/OGL/test/data_validation.py workspace
+        # python3 /__w/OGL/OGL/test/data_validation.py workspace
         ls -la workspace/*/case/processor0/*
 
     - name: Validate state

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,7 +174,8 @@ jobs:
       working-directory: /github/home/${{matrix.Case}}
       shell: bash
       run: |
-        python3 /__w/OGL/OGL/test/data_validation.py workspace
+        # python3 /__w/OGL/OGL/test/data_validation.py workspace
+        ls -la workspace/*/case/processor0/*
 
     - name: Validate state
       working-directory: /github/home/${{matrix.Case}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -112,7 +112,6 @@ jobs:
     - name: Get Ginkgo checkout version
       shell: bash
       run: |
-
         grep -A1 "set(GINKGO_CHECKOUT_VERSION" CMakeLists.txt|tail -n1|grep -o  "[0-9a-z]*" > GINKGO_CHECKOUT_VERSION
         export GINKGO_CHECKOUT_VERSION=$(cat GINKGO_CHECKOUT_VERSION)
         echo "GINKGO_CHECKOUT_VERSION=$GINKGO_CHECKOUT_VERSION" >> $GITHUB_ENV
@@ -170,6 +169,12 @@ jobs:
         #     run: |
         #       STATE_CACHE_KEY="ws"
         #       echo "STATE_CACHE_KEY=${STATE_CACHE_KEY}" >> $GITHUB_ENV 
+
+    - name: Validation of exported mtx files
+      working-directory: /github/home/${{matrix.Case}}
+      shell: bash
+      run: |
+        python /__w/OGL/OGL/test/data_validation.py workspace
 
     - name: Validate state
       working-directory: /github/home/${{matrix.Case}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,7 +174,7 @@ jobs:
       working-directory: /github/home/${{matrix.Case}}
       shell: bash
       run: |
-        python /__w/OGL/OGL/test/data_validation.py workspace
+        python3 /__w/OGL/OGL/test/data_validation.py workspace
 
     - name: Validate state
       working-directory: /github/home/${{matrix.Case}}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -174,7 +174,7 @@ jobs:
       working-directory: /github/home/${{matrix.Case}}
       shell: bash
       run: |
-        # python3 /__w/OGL/OGL/test/data_validation.py workspace
+        python3 /__w/OGL/OGL/test/data_validation.py workspace
         ls -la workspace/*/case/processor0/*
 
     - name: Validate state

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Cache FOAM_USER_LIBBIN
       uses: actions/cache@v3
       with:
-        key: FOAM_USER_LIBBIN-${{ matrix.Case }}-${{ github.sha }}
+        key: FOAM_USER_LIBBIN-${{ matrix.version }}-${{ github.sha }}
         path: |
           ${{env.FOAM_USER_LIBBIN}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Cache FOAM_USER_LIBBIN
       uses: actions/cache@v3
       with:
-        key: FOAM_USER_LIBBIN-${{ matrix.version }}-${{ github.sha }}
+        key: FOAM_USER_LIBBIN-${{ inputs.version }}-${{ github.sha }}
         path: |
           ${{env.FOAM_USER_LIBBIN}}
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -136,7 +136,14 @@ jobs:
         key: build-${{ inputs.path }}-${{env.GINKGO_CHECKOUT_VERSION}}
         path: |
           ${{github.workspace}}/build
+
+    - name: Cache FOAM_USER_LIBBIN
+      uses: actions/cache@v3
+      with:
+        key: FOAM_USER_LIBBIN-${{ matrix.OF.path }}-${{ github.sha }}
+        path: |
           ${{env.FOAM_USER_LIBBIN}}
+
 
     - name: Check folders
       run: |
@@ -146,7 +153,7 @@ jobs:
     - name: Cache Workspace
       uses: actions/cache@v3
       with:
-        key: ws-${{inputs.version}}-${{matrix.Case}}-${{ github.sha }}-${{ hashFiles(format('/__w/OGL/OGL/test/{0}.yaml', matrix.Case)) }}
+        key: ws-${{inputs.version}}-${{matrix.Case}}-${{ github.sha }}
         path: /home/runner/work/_temp/_github_home/${{matrix.Case}}
 
               #   - name: Copy OGL from cached folder

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Cache workspace
       uses: actions/cache@v3
       with:
-        key: ws-${{inputs.version}}-${{matrix.Case}}-${{ github.sha }}-${{ hashFiles(format('/__w/OGL/OGL/test/{0}.yaml', matrix.Case)) }}
+        key: ws-${{inputs.version}}-${{matrix.Case}}-${{ github.sha }}
         path: /home/runner/work/_temp/_github_home/${{matrix.Case}}
 
     - name: Generate test cases

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -140,7 +140,7 @@ jobs:
     - name: Cache FOAM_USER_LIBBIN
       uses: actions/cache@v3
       with:
-        key: FOAM_USER_LIBBIN-${{ matrix.OF.path }}-${{ github.sha }}
+        key: FOAM_USER_LIBBIN-${{ matrix.Case }}-${{ github.sha }}
         path: |
           ${{env.FOAM_USER_LIBBIN}}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ if(NOT ${OGL_USE_EXTERNAL_GINKGO})
 endif()
 
 # C++ 14 standard or later is required to interface with ginkgo 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -63,6 +63,8 @@ struct MatrixInitFunctor {
 
     const word matrix_format_;
 
+    const bool regenerate_;
+
     const label verbose_;
 
     const word field_name_;
@@ -75,8 +77,8 @@ struct MatrixInitFunctor {
                       const PersistentArray<label> &non_local_col_idxs,
                       const PersistentArray<label> &non_local_row_idxs,
                       const PersistentArray<scalar> &non_local_coeffs,
-                      const word matrix_format, const label verbose,
-                      const word field_name)
+                      const word matrix_format, const bool regenerate,
+                      const label verbose, const word field_name)
         : db_(db),
           exec_(exec),
           partition_(partition),
@@ -87,12 +89,20 @@ struct MatrixInitFunctor {
           non_local_row_idxs_(non_local_row_idxs),
           non_local_coeffs_(non_local_coeffs),
           matrix_format_(matrix_format),
+          regenerate_(regenerate),
           verbose_(verbose),
           field_name_(field_name)
     {}
 
     void update(std::shared_ptr<dist_mtx> persistent_device_matrix) const
     {
+        if (regenerate_) {
+            TIME_WITH_FIELDNAME(
+                verbose_, regenerate_distributed_matrix, field_name_,
+                persistent_device_matrix = generate_dist_mtx_with_inner_type(
+                    exec_.get_device_exec(), exec_.get_gko_mpi_device_comm());)
+            return;
+        }
         auto coeffs = coeffs_.get_array();
         auto non_local_coeffs = non_local_coeffs_.get_array();
 
@@ -494,6 +504,7 @@ public:
                   db, exec, partition, col_idxs, row_idxs, coeffs,
                   non_local_col_idxs, non_local_row_idxs, non_local_coeffs,
                   controlDict.lookupOrDefault<word>("matrixFormat", "Coo"),
+                  controlDict.lookupOrDefault<Switch>("regenerate", false),
                   verbose_, sys_matrix_name),
               controlDict.lookupOrDefault<Switch>("updateSysMatrix", true),
               verbose_}

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -97,10 +97,9 @@ struct MatrixInitFunctor {
     void update(std::shared_ptr<dist_mtx> persistent_device_matrix) const
     {
         if (regenerate_) {
-            TIME_WITH_FIELDNAME(
-                verbose_, regenerate_distributed_matrix, field_name_,
-                auto reinit = init();)
-                persistent_device_matrix->copy_from(reinit.get());
+            TIME_WITH_FIELDNAME(verbose_, regenerate_distributed_matrix,
+                                field_name_, auto reinit = init();)
+            persistent_device_matrix->copy_from(reinit.get());
             return;
         }
         auto coeffs = coeffs_.get_array();

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -99,8 +99,8 @@ struct MatrixInitFunctor {
         if (regenerate_) {
             TIME_WITH_FIELDNAME(
                 verbose_, regenerate_distributed_matrix, field_name_,
-                persistent_device_matrix = generate_dist_mtx_with_inner_type(
-                    exec_.get_device_exec(), exec_.get_gko_mpi_device_comm());)
+                auto reinit = init();)
+                persistent_device_matrix->copy_from(reinit.get());
             return;
         }
         auto coeffs = coeffs_.get_array();

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -293,8 +293,6 @@ struct MatrixInitFunctor {
 
     std::shared_ptr<dist_mtx> init() const
     {
-        using coo_mtx = gko::matrix::Coo<scalar>;
-
         label nCells = partition_.get_local_host_size();
         word msg{"init global csr matrix of size " + std::to_string(nCells)};
         LOG_1(verbose_, msg)

--- a/DevicePersistent/Partition/Partition.H
+++ b/DevicePersistent/Partition/Partition.H
@@ -66,7 +66,9 @@ struct PartitionInitFunctor {
     void update(
         std::shared_ptr<gko::experimental::distributed::Partition<label, label>>
             persistent_partition) const
-    {UNUSED(persistent_partition);}
+    {
+        UNUSED(persistent_partition);
+    }
 
     std::shared_ptr<gko::experimental::distributed::Partition<label, label>>
     init() const

--- a/DevicePersistent/Partition/Partition.H
+++ b/DevicePersistent/Partition/Partition.H
@@ -66,7 +66,7 @@ struct PartitionInitFunctor {
     void update(
         std::shared_ptr<gko::experimental::distributed::Partition<label, label>>
             persistent_partition) const
-    {}
+    {UNUSED(persistent_partition);}
 
     std::shared_ptr<gko::experimental::distributed::Partition<label, label>>
     init() const

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -31,13 +31,13 @@ SourceFiles
 
 namespace Foam {
 
-const lduInterfaceField* interface_getter(
-        const lduInterfaceFieldPtrsList &interfaces,
-        const label i){
+const lduInterfaceField *interface_getter(
+    const lduInterfaceFieldPtrsList &interfaces, const label i)
+{
 #ifdef WITH_ESI_VERSION
-        return interfaces.get(i);
+    return interfaces.get(i);
 #else
-        return interfaces.operator()(i);
+    return interfaces.operator()(i);
 #endif
 };
 
@@ -47,10 +47,10 @@ label HostMatrixWrapper<MatrixType>::count_interface_nnz(
 {
     label ctr{0};
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
 
         bool count = (proc_interfaces)
                          ? !!isA<processorLduInterface>(iface->interface())
@@ -75,10 +75,10 @@ std::vector<scalar> HostMatrixWrapper<MatrixType>::collect_interface_coeffs(
     ret.reserve((local) ? local_interface_nnz_ : non_local_matrix_nnz_);
 
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
         auto coeffs{interfaceBouCoeffs[i]};
 
         bool collect = (local)
@@ -111,11 +111,11 @@ HostMatrixWrapper<MatrixType>::collect_local_interface_indices(
     local_interface_idxs.reserve(local_interface_nnz_);
 
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
 
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
 
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
@@ -160,11 +160,11 @@ HostMatrixWrapper<MatrixType>::collect_non_local_col_indices(
 
     label startOfRequests = Pstream::nRequests();
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
 
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
         const auto &face_cells{iface->interface().faceCells()};
 
         if (isA<processorLduInterface>(iface->interface())) {
@@ -185,11 +185,11 @@ HostMatrixWrapper<MatrixType>::collect_non_local_col_indices(
 
     label interface_ctr = 0;
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
 
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
 
@@ -243,11 +243,11 @@ void HostMatrixWrapper<MatrixType>::init_non_local_sparsity_pattern(
 
     label interface_ctr = 0;
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
 
-        const auto &iface{interface_getter(interfaces,i)};
+        const auto &iface{interface_getter(interfaces, i)};
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
 
@@ -384,7 +384,7 @@ void HostMatrixWrapper<MatrixType>::init_local_sparsity_pattern(
         // iterate local interfaces i
         // insert all coeffs for row < interface[i].row
         // find local_interface with lowes row, column
-	for (auto const& interface : local_interfaces){
+        for (auto const &interface : local_interfaces) {
             auto [interface_idx, interface_row, interface_col] = interface;
 
             // copy from existing matrix coefficients
@@ -556,10 +556,10 @@ void HostMatrixWrapper<MatrixType>::update_non_local_matrix_data(
 
     label interface_ctr{0};
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interface_getter(interfaces,i) == nullptr) {
+        if (interface_getter(interfaces, i) == nullptr) {
             continue;
         }
-        const auto iface{interface_getter(interfaces,i)};
+        const auto iface{interface_getter(interfaces, i)};
         const label patch_size = iface->interface().faceCells().size();
 
         if (!isA<processorLduInterface>(iface->interface())) {

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -38,10 +38,10 @@ label HostMatrixWrapper<MatrixType>::count_interface_nnz(
 {
     label ctr{0};
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
 
         bool count = (proc_interfaces)
                          ? !!isA<processorLduInterface>(iface->interface())
@@ -66,10 +66,10 @@ std::vector<scalar> HostMatrixWrapper<MatrixType>::collect_interface_coeffs(
     ret.reserve((local) ? local_interface_nnz_ : non_local_matrix_nnz_);
 
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
         auto coeffs{interfaceBouCoeffs[i]};
 
         bool collect = (local)
@@ -102,11 +102,11 @@ HostMatrixWrapper<MatrixType>::collect_local_interface_indices(
     local_interface_idxs.reserve(local_interface_nnz_);
 
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
 
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
 
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
@@ -151,11 +151,11 @@ HostMatrixWrapper<MatrixType>::collect_non_local_col_indices(
 
     label startOfRequests = Pstream::nRequests();
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
 
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
         const auto &face_cells{iface->interface().faceCells()};
 
         if (isA<processorLduInterface>(iface->interface())) {
@@ -176,11 +176,11 @@ HostMatrixWrapper<MatrixType>::collect_non_local_col_indices(
 
     label interface_ctr = 0;
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
 
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
 
@@ -234,11 +234,11 @@ void HostMatrixWrapper<MatrixType>::init_non_local_sparsity_pattern(
 
     label interface_ctr = 0;
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
 
-        const auto &iface{interfaces.operator()(i)};
+        const auto &iface{interfaces.get(i)};
         const auto &face_cells{iface->interface().faceCells()};
         const label interface_size = face_cells.size();
 
@@ -375,9 +375,8 @@ void HostMatrixWrapper<MatrixType>::init_local_sparsity_pattern(
         // iterate local interfaces i
         // insert all coeffs for row < interface[i].row
         // find local_interface with lowes row, column
-        for (int i = 0; i < local_interfaces.size(); i++) {
-            auto [interface_idx, interface_row, interface_col] =
-                local_interfaces[i];
+	for (auto const& interface : local_interfaces){
+            auto [interface_idx, interface_row, interface_col] = interface;
 
             // copy from existing matrix coefficients
             while ([&]() {
@@ -441,9 +440,6 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
     auto diag = this->matrix().diag();
     label diag_nnz = diag.size();
     bool is_symmetric{this->matrix().symmetric()};
-
-    label contiguous_size =
-        (is_symmetric) ? nrows_ + upper_nnz_ : local_matrix_nnz_;
 
     auto dense_vec = vec::create(
         ref_exec,
@@ -551,10 +547,10 @@ void HostMatrixWrapper<MatrixType>::update_non_local_matrix_data(
 
     label interface_ctr{0};
     for (int i = 0; i < interfaces.size(); i++) {
-        if (interfaces.operator()(i) == nullptr) {
+        if (interfaces.get(i) == nullptr) {
             continue;
         }
-        const auto iface{interfaces.operator()(i)};
+        const auto iface{interfaces.get(i)};
         const label patch_size = iface->interface().faceCells().size();
 
         if (!isA<processorLduInterface>(iface->interface())) {

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -268,7 +268,7 @@ void HostMatrixWrapper<MatrixType>::init_local_sparsity_pattern(
     const lduInterfaceFieldPtrsList &interfaces) const
 {
     LOG_1(verbose_, "start init host sparsity pattern")
-    bool is_symmetric{this->matrix().upper() == this->matrix().lower()};
+    bool is_symmetric{this->matrix().symmetric()};
 
     auto lower_local = idx_array::view(
         exec_.get_ref_exec(), upper_nnz_ - local_interface_nnz_,
@@ -440,8 +440,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
     auto lower = this->matrix().lower();
     auto diag = this->matrix().diag();
     label diag_nnz = diag.size();
-
-    bool is_symmetric{upper == lower};
+    bool is_symmetric{this->matrix().symmetric()};
 
     label contiguous_size =
         (is_symmetric) ? nrows_ + upper_nnz_ : local_matrix_nnz_;

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -315,7 +315,7 @@ void HostMatrixWrapper<MatrixType>::init_local_sparsity_pattern(
     for (label row = 0; row < nrows_; row++) {
         // add lower elements
         // for now just scan till current upper ctr
-        for (const auto [stored_upper_ctr, col] : lower_stack[row]) {
+        for (const auto &[stored_upper_ctr, col] : lower_stack[row]) {
             rows[element_ctr] = row;
             cols[element_ctr] = col;
             permute[element_ctr] = stored_upper_ctr;

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -447,6 +447,9 @@ public:
         auto po = new DevicePersistentBase<gko::LinOp>(IOobject(path, db_),
                                                        generated_precond);
 
+        // use get_ptr(() to avoid unused variable warning
+        po->get_ptr();
+
         return generated_precond;
     };
 };

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -40,7 +40,7 @@ class Preconditioner {
     using ir = gko::solver::Ir<scalar>;
     using cg = gko::solver::Cg<scalar>;
     using mg = gko::solver::Multigrid;
-    using amgx_pgm = gko::multigrid::AmgxPgm<scalar, label>;
+    using amgx_pgm = gko::multigrid::Pgm<scalar, label>;
     using ras =
         gko::experimental::distributed::preconditioner::Schwarz<scalar, label,
                                                                 label>;

--- a/common/common.C
+++ b/common/common.C
@@ -62,9 +62,12 @@ void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
     auto time_name = db.time().timeName();
     auto folder =
         "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
+    std::cout << "Export system: "  + folder + "\n";
     std::filesystem::create_directories(folder);
     std::string fn{folder + fieldName + "_A_" + local + ".mtx"};
+    std::cout << "Export system file: "  + fn + "\n";
     std::ofstream stream{fn};
+    std::cout << "Export system write: "  + fn + "\n";
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
 }
 

--- a/common/common.C
+++ b/common/common.C
@@ -25,6 +25,7 @@ SourceFiles
 
 #include <ginkgo/ginkgo.hpp>
 #include <map>
+#include <iomanip>
 #include <type_traits>
 
 #include <filesystem>
@@ -63,6 +64,7 @@ void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
     std::filesystem::create_directories(folder);
     std::string fn{folder + "/" + fieldName + "_A_" + local + ".mtx"};
     std::ofstream stream{fn};
+    stream << std::setprecision(15);
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
 }
 

--- a/common/common.C
+++ b/common/common.C
@@ -24,8 +24,8 @@ SourceFiles
 \*---------------------------------------------------------------------------*/
 
 #include <ginkgo/ginkgo.hpp>
-#include <map>
 #include <iomanip>
+#include <map>
 #include <type_traits>
 
 #include <filesystem>

--- a/common/common.C
+++ b/common/common.C
@@ -28,6 +28,7 @@ SourceFiles
 #include <type_traits>
 
 #include "common.H"
+#include <filesystem>
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
@@ -59,18 +60,12 @@ void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db)
 {
     auto time_name = db.time().timeName();
-    std::cout << "time name \n;";
     auto folder =
         "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
-    std::cout << "folder \n;";
-    system("mkdir -p " + folder);
-    std::cout << "mkdir -p \n;";
+    std::filesystem::create_directories(folder);
     std::string fn{folder + fieldName + "_A_" + local + ".mtx"};
-    std::cout << "fn\n";
     std::ofstream stream{fn};
-    std::cout << "ofstream\n";
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
-    std::cout << "write\n";
 }
 
 void export_system(const word fieldName, const gko::matrix::Csr<scalar> *A,

--- a/common/common.C
+++ b/common/common.C
@@ -59,15 +59,12 @@ void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db)
 {
-    auto time_name = db.time().timeName();
-    auto folder =
-        "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
-    std::cout << "Export system: "  + folder + "\n";
+    std::string folder{db.time().timePath().path()};
     std::filesystem::create_directories(folder);
-    std::string fn{folder + fieldName + "_A_" + local + ".mtx"};
-    std::cout << "Export system file: "  + fn + "\n";
+    std::string fn{folder + "/" + fieldName + "_A_" + local + ".mtx"};
+    std::cout << "Export system file: " + fn + "\n";
     std::ofstream stream{fn};
-    std::cout << "Export system write: "  + fn + "\n";
+    std::cout << "Export system write: " + fn + "\n";
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
 }
 

--- a/common/common.C
+++ b/common/common.C
@@ -59,12 +59,10 @@ void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db)
 {
-    std::string folder{db.time().timePath().path()};
+    std::string folder{db.time().timePath()};
     std::filesystem::create_directories(folder);
     std::string fn{folder + "/" + fieldName + "_A_" + local + ".mtx"};
-    std::cout << "Export system file: " + fn + "\n";
     std::ofstream stream{fn};
-    std::cout << "Export system write: " + fn + "\n";
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
 }
 

--- a/common/common.C
+++ b/common/common.C
@@ -27,8 +27,8 @@ SourceFiles
 #include <map>
 #include <type_traits>
 
-#include "common.H"
 #include <filesystem>
+#include "common.H"
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 

--- a/common/common.C
+++ b/common/common.C
@@ -59,12 +59,18 @@ void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db)
 {
     auto time_name = db.time().timeName();
+    std::cout << "time name \n;";
     auto folder =
         "processor" + Foam::name(Pstream::myProcNo()) + "/" + time_name + "/";
+    std::cout << "folder \n;";
     system("mkdir -p " + folder);
+    std::cout << "mkdir -p \n;";
     std::string fn{folder + fieldName + "_A_" + local + ".mtx"};
+    std::cout << "fn\n";
     std::ofstream stream{fn};
+    std::cout << "ofstream\n";
     gko::write(stream, (const gko::matrix::Coo<scalar> *)A.get());
+    std::cout << "write\n";
 }
 
 void export_system(const word fieldName, const gko::matrix::Csr<scalar> *A,

--- a/common/common.H
+++ b/common/common.H
@@ -104,6 +104,7 @@ namespace Foam {
 
 #define SIMPLE_TIME(VERBOSE, NAME, F) TIME_WITH_FIELDNAME(VERBOSE, NAME, "", F)
 
+#define UNUSED(x) (void)(x)
 
 std::ostream &operator<<(
     std::ostream &os,

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -324,7 +324,7 @@ public:
         solverPerf.nIterations() = this->get_number_of_iterations();
         this->store_number_of_iterations();
         auto time_for_res_norm_eval = this->get_res_norm_time();
-        auto time_per_iter = delta_t_solve / this->get_number_of_iterations();
+        auto time_per_iter = delta_t_solve / max(this->get_number_of_iterations(), 1);
         scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
         this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
             this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1, 0);

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -284,6 +284,7 @@ public:
 
         bool debug(solver_controls_.lookupOrDefault<Switch>("debug", false));
         if (debug && db_.time().writeTime()) {
+            LOG_0(verbose_, "Export system")
             export_mtx(
                 this->fieldName(),
                 gko::as<gko::experimental::distributed::Matrix<scalar, label,

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -282,7 +282,7 @@ public:
             auto precond = this->init_preconditioner(
                 dist_A_v, this->get_exec_handler().get_device_exec());)
 
-        bool debug(solverControls.lookupOrDefault<Switch>("debug", false));
+        bool debug(solver_controls_.lookupOrDefault<Switch>("debug", false));
         if (debug && db_.time().writeTime()) {
             export_mtx(
                 this->fieldName(),

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -282,9 +282,7 @@ public:
             auto precond = this->init_preconditioner(
                 dist_A_v, this->get_exec_handler().get_device_exec());)
 
-#ifdef DATA_VALIDATION
-        // TODO improve this
-        if (db_.time().writeTime()) {
+        if (debug_ && db_.time().writeTime()) {
             export_mtx(
                 this->fieldName(),
                 gko::as<gko::experimental::distributed::Matrix<scalar, label,
@@ -298,7 +296,6 @@ public:
                     ->get_non_local_matrix(),
                 "non_local", db_);
         }
-#endif
 
 
         LOG_1(verbose_, "create solver")

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -324,7 +324,8 @@ public:
         solverPerf.nIterations() = this->get_number_of_iterations();
         this->store_number_of_iterations();
         auto time_for_res_norm_eval = this->get_res_norm_time();
-        auto time_per_iter = delta_t_solve / max(this->get_number_of_iterations(), 1);
+        auto time_per_iter =
+            delta_t_solve / max(this->get_number_of_iterations(), 1);
         scalar prev_rel_res_cost = time_per_iter / time_for_res_norm_eval;
         this->get_exec_handler().get_gko_mpi_host_comm()->broadcast(
             this->get_exec_handler().get_ref_exec(), &prev_rel_res_cost, 1, 0);

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -282,7 +282,8 @@ public:
             auto precond = this->init_preconditioner(
                 dist_A_v, this->get_exec_handler().get_device_exec());)
 
-        if (debug_ && db_.time().writeTime()) {
+        bool debug(solverControls.lookupOrDefault<Switch>("debug", false));
+        if (debug && db_.time().writeTime()) {
             export_mtx(
                 this->fieldName(),
                 gko::as<gko::experimental::distributed::Matrix<scalar, label,

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -21,7 +21,7 @@ variation:
         solver: GKOCG
         forceHostBuffer: 1
         verbose: 1
-        debug: 0
+        debug: 1
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
         preconditioner: BJ
@@ -29,5 +29,5 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         regenerate: 1
-        debug: 0
+        debug: 1
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -6,7 +6,7 @@ case:
     post_build:
       - controlDict:
            libs: [libOGL.so]
-           writeIntervall: 1
+           writeInterval: 1
       - blockMesh
       - decomposePar:
             method: simple

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -26,5 +26,5 @@ variation:
         solver: GKOBiCGStab
         forceHostBuffer: 1
         verbose: 1
-        regenerate: on
+        regenerate: true
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -22,13 +22,11 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         debug: 1
-        regenerate: 1
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
         preconditioner: BJ
         solver: GKOBiCGStab
         forceHostBuffer: 1
         verbose: 1
-        regenerate: 1
         debug: 1
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -26,5 +26,5 @@ variation:
         solver: GKOBiCGStab
         forceHostBuffer: 1
         verbose: 1
-        regenerate: true
+        regenerate: 1
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -6,6 +6,7 @@ case:
     post_build:
       - controlDict:
            libs: [libOGL.so]
+           writeIntervall: 1
       - blockMesh
       - decomposePar:
             method: simple

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -21,6 +21,7 @@ variation:
         solver: GKOCG
         forceHostBuffer: 1
         verbose: 1
+        debug: 1
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
         preconditioner: BJ
@@ -28,4 +29,5 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         regenerate: 1
+        debug: 1
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -22,7 +22,7 @@ variation:
         verbose: 1
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
-        preconditioner: none
+        preconditioner: BJ
         solver: GKOBiCGStab
         forceHostBuffer: 1
         verbose: 1

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -21,7 +21,7 @@ variation:
         solver: GKOCG
         forceHostBuffer: 1
         verbose: 1
-        debug: 1
+        debug: 0
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
         preconditioner: BJ
@@ -29,5 +29,5 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         regenerate: 1
-        debug: 1
+        debug: 0
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -26,4 +26,5 @@ variation:
         solver: GKOBiCGStab
         forceHostBuffer: 1
         verbose: 1
+        regenerate: on
         executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -6,7 +6,7 @@ case:
     post_build:
       - controlDict:
            libs: [libOGL.so]
-           writeInterval: 1
+           writeInterval: 10
       - blockMesh
       - decomposePar:
             method: simple

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -21,3 +21,9 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         executor: ${{env.GINKGO_EXECUTOR}}
+      - set: solvers/U
+        preconditioner: none
+        solver: GKOBiCGStab
+        forceHostBuffer: 1
+        verbose: 1
+        executor: ${{env.GINKGO_EXECUTOR}}

--- a/test/cavity.yaml
+++ b/test/cavity.yaml
@@ -22,6 +22,7 @@ variation:
         forceHostBuffer: 1
         verbose: 1
         debug: 1
+        regenerate: 1
         executor: ${{env.GINKGO_EXECUTOR}}
       - set: solvers/U
         preconditioner: BJ

--- a/test/cavity_validation.json
+++ b/test/cavity_validation.json
@@ -29,7 +29,7 @@
           "properties": {
             "timeStepContErrors_sumLocal": {
               "type": "number",
-              "exclusiveMaximum": 1e-08
+              "exclusiveMaximum": 1e-07
             }
           }
         }

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+def test_matrix_presence(workspace: str):
+    """This function checks for the pressence of matrix files"""
+    mtx_files = []
+    for root, folder, files in os.walk(workspace):
+        for file in files:
+            if file.endswith(".mtx"):
+                mtx_files.append(f"{root}/{file}")
+    if not mtx_files:
+        raise ValueError("no .mtx files found")
+        sys.exit(1)
+    print(f"PASS found {len(mtx_files)} .mtx files")
+
+
+def main():
+    workspace = sys.argv[1]
+    test_matrix_presence(workspace)
+
+
+if __name__ == "__main__":
+    main()
+
+

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -1,5 +1,10 @@
 import os
 import sys
+import collections
+
+from subprocess import check_output
+from logging import info
+
 
 def find_mtx_files(workspace: str) -> tuple:
     mtx_files = []
@@ -7,11 +12,26 @@ def find_mtx_files(workspace: str) -> tuple:
         for file in files:
             if file.endswith(".mtx"):
                 time = root.split("/")[-1]
-                mtx_files.append((time, f"{root}/{file}"))
+                proc = root.split("/")[-2]
+                field_name = file.split("_")[0]
+                file_path = f"{root}/{file}"
+                md5sum = check_output(["md5sum", file_path], text=True).split()[0]
+
+                mtx_files.append(
+                    {
+                        "time": time,
+                        "proc": proc,
+                        "field": field_name,
+                        "path": file_path,
+                        "md5sum": md5sum,
+                    }
+                )
     return mtx_files
+
 
 def test_matrix_presence(workspace: str):
     """This function checks for the pressence of matrix files"""
+    print("check if matrix files exist")
     mtx_files = find_mtx_files(workspace)
     if not mtx_files:
         raise ValueError("no .mtx files found")
@@ -19,12 +39,65 @@ def test_matrix_presence(workspace: str):
     print(f"PASS found {len(mtx_files)} .mtx files")
 
 
+def test_if_matrices_are_unique(workspace):
+    """This function checks if matrices are different for different timesteps"""
+    mtx_files = find_mtx_files(workspace)
+    md5sums = [
+        (record["field"], record["proc"], record["md5sum"])
+        for record in mtx_files
+        if (record["time"] == "0.05") or (record["time"] == "0.5")
+    ]
+    duplicates = [
+        item for item, count in collections.Counter(md5sums).items() if count > 1
+    ]
+
+    if len(duplicates) != 0:
+        for dup in duplicates:
+            for mtx_file in mtx_files:
+                if mtx_file["md5sum"] == dup[2]:
+                    print(mtx_file)
+
+        raise ValueError("Not all .mtx files are unique")
+        sys.exit(1)
+    print(f"PASS all tested {len(md5sums)} .mtx files are unique")
+
+
+def verify_local_matrix(lines, file_path):
+    for line in lines:
+        row, col, val = line.split(" ")
+        val = float(val)
+        if row == col:
+            if (val > 0.001) or (val < 0.0):
+                raise ValueError(
+                    f"diag value {row} {col} {val} is out of bounds 0, {file_path}"
+                )
+                sys.exit(1)
+        else:
+            if (val > 0) or (val < -0.001):
+                raise ValueError(
+                    f"off diag {row} {col} {val} is out of bounds 0, {file_path}"
+                )
+                sys.exit(1)
+
+
+def test_matrix_value_bounds(workspace):
+    """This function checks if matrices are coeffs are within bounds"""
+    mtx_files = find_mtx_files(workspace)
+    for record in mtx_files:
+        file_path = record["path"]
+        if not "_local_" in file_path:
+            continue
+        with open(file_path) as fh:
+            verify_local_matrix(fh.readlines()[2:], file_path)
+    print(f"PASS all tested .mtx files are within bounds")
+
+
 def main():
     workspace = sys.argv[1]
     test_matrix_presence(workspace)
+    test_if_matrices_are_unique(workspace)
+    test_matrix_value_bounds(workspace)
 
 
 if __name__ == "__main__":
     main()
-
-

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -13,6 +13,7 @@ def find_mtx_files(workspace: str) -> tuple:
             if file.endswith(".mtx"):
                 time = root.split("/")[-1]
                 proc = root.split("/")[-2]
+                uid = root.split("/")[-4]
                 field_name = file.split("_")[0]
                 file_path = f"{root}/{file}"
                 md5sum = check_output(["md5sum", file_path], text=True).split()[0]
@@ -24,6 +25,7 @@ def find_mtx_files(workspace: str) -> tuple:
                         "field": field_name,
                         "path": file_path,
                         "md5sum": md5sum,
+                        "uid": uid,
                     }
                 )
     return mtx_files
@@ -43,7 +45,7 @@ def test_if_matrices_are_unique(workspace):
     """This function checks if matrices are different for different timesteps"""
     mtx_files = find_mtx_files(workspace)
     md5sums = [
-        (record["field"], record["proc"], record["md5sum"])
+        (record["field"], record["proc"], record["md5sum"], record["uid"])
         for record in mtx_files
         if (record["time"] == "0.05") or (record["time"] == "0.5")
     ]

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -32,7 +32,7 @@ def find_mtx_files(workspace: str) -> tuple:
 
 
 def test_matrix_presence(workspace: str):
-    """This function checks for the pressence of matrix files"""
+    """This function checks for the presence of matrix files"""
     print("check if matrix files exist")
     mtx_files = find_mtx_files(workspace)
     if not mtx_files:

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -12,7 +12,8 @@ from logging import info
 
 
 def find_mtx_files(workspace: str) -> list[dict]:
-    """Given a workspace path this function searches for .mtx files and returns a dictionary of with basic properties of the mtx file
+    """Given a workspace path this function searches for .mtx files and returns
+    a dictionary of with basic properties of the mtx file
 
     Returns:
         a dictionary containing:
@@ -48,8 +49,9 @@ def find_mtx_files(workspace: str) -> list[dict]:
 
 
 def test_matrix_presence(workspace: str):
-    """This function checks for the presence of matrix files. If no matrix files where found
-    it raises a ValueError"""
+    """This function checks for the presence of matrix files. If no matrix
+    files where found it raises a ValueError
+    """
     print("check if matrix files exist")
     mtx_files = find_mtx_files(workspace)
     if not mtx_files:
@@ -59,7 +61,10 @@ def test_matrix_presence(workspace: str):
 
 
 def test_if_matrices_are_unique(workspace):
-    """This function checks if matrices are different for different timesteps. If matrices are constant it would indicate that the matrix update is not working"""
+    """This function checks if matrices are different for different timesteps.
+    If matrices are constant it would indicate that the matrix update is not
+    working
+    """
     mtx_files = find_mtx_files(workspace)
     md5sums = [
         (record["field"], record["proc"], record["md5sum"], record["uid"])
@@ -82,7 +87,9 @@ def test_if_matrices_are_unique(workspace):
 
 
 def verify_local_matrix(lines, file_path):
-    """This function checks if matrix coefficients are within reasonable bounds for the lidDrivenCavity case"""
+    """This function checks if matrix coefficients are within reasonable bounds
+    for the lidDrivenCavity case
+    """
     for line in lines:
         row, col, val = line.split(" ")
         val = float(val)

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -1,13 +1,18 @@
 import os
 import sys
 
-def test_matrix_presence(workspace: str):
-    """This function checks for the pressence of matrix files"""
+def find_mtx_files(workspace: str) -> tuple:
     mtx_files = []
     for root, folder, files in os.walk(workspace):
         for file in files:
             if file.endswith(".mtx"):
-                mtx_files.append(f"{root}/{file}")
+                time = root.split("/")[-1]
+                mtx_files.append((time, f"{root}/{file}"))
+    return mtx_files
+
+def test_matrix_presence(workspace: str):
+    """This function checks for the pressence of matrix files"""
+    mtx_files = find_mtx_files(workspace)
     if not mtx_files:
         raise ValueError("no .mtx files found")
         sys.exit(1)

--- a/test/data_validation.py
+++ b/test/data_validation.py
@@ -1,3 +1,8 @@
+""" This python script performs basic validation of exported matrices for the lidDrivenCavity case.
+"""
+# TODO check if pressure matrix is symmetric
+# TODO check if momentum matrix is non-symmetric
+
 import os
 import sys
 import collections
@@ -6,7 +11,18 @@ from subprocess import check_output
 from logging import info
 
 
-def find_mtx_files(workspace: str) -> tuple:
+def find_mtx_files(workspace: str) -> list[dict]:
+    """Given a workspace path this function searches for .mtx files and returns a dictionary of with basic properties of the mtx file
+
+    Returns:
+        a dictionary containing:
+          - the timestep in which the matrix was exported
+          - the processor folder in which the matrix was stored
+          - the field for which the matrix was written
+          - the full file path of the matrix file
+          - the md5sum of the mtx file
+          - the signac uid of the simulation
+    """
     mtx_files = []
     for root, folder, files in os.walk(workspace):
         for file in files:
@@ -32,7 +48,8 @@ def find_mtx_files(workspace: str) -> tuple:
 
 
 def test_matrix_presence(workspace: str):
-    """This function checks for the presence of matrix files"""
+    """This function checks for the presence of matrix files. If no matrix files where found
+    it raises a ValueError"""
     print("check if matrix files exist")
     mtx_files = find_mtx_files(workspace)
     if not mtx_files:
@@ -42,7 +59,7 @@ def test_matrix_presence(workspace: str):
 
 
 def test_if_matrices_are_unique(workspace):
-    """This function checks if matrices are different for different timesteps"""
+    """This function checks if matrices are different for different timesteps. If matrices are constant it would indicate that the matrix update is not working"""
     mtx_files = find_mtx_files(workspace)
     md5sums = [
         (record["field"], record["proc"], record["md5sum"], record["uid"])
@@ -65,6 +82,7 @@ def test_if_matrices_are_unique(workspace):
 
 
 def verify_local_matrix(lines, file_path):
+    """This function checks if matrix coefficients are within reasonable bounds for the lidDrivenCavity case"""
     for line in lines:
         row, col, val = line.split(" ")
         val = float(val)


### PR DESCRIPTION
Currently, OGL fails if linear solver does zero iterations.

Besides several minor issues are solved:
- Require c++ 17 standard
- Add option to fully regenerate matrix
- fixes issue with detection of non symmetric matrices
- export matrix when debug flag is set
- add matrix data validation via python script