### PR TITLE
Permute on device implementation

### DIFF
--- a/.github/workflows/build-foam.yml
+++ b/.github/workflows/build-foam.yml
@@ -88,7 +88,7 @@ jobs:
         mkdir -p build
         cd build
         [ -d "/github/home/$GINKGO_CHECKOUT_VERSION" ] && cp -rp /github/home/$GINKGO_CHECKOUT_VERSION third_party
-        cmake -G Ninja -DOGL_ALLOW_REFERENCE_ONLY=On -DOGL_BUILD_UNITTEST=OFF -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+        cmake -G Ninja -DOGL_ALLOW_REFERENCE_ONLY=On -DOGL_BUILD_UNITTEST=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
 
     - name: Build OGL
       working-directory: ${{github.workspace}}/build
@@ -114,14 +114,14 @@ jobs:
         name: ogl_build_${{ matrix.OF.path }}
         path: ${{github.workspace}}/build
 
-  # unit_tests:
-  #   needs: [build, setup_build_matrix]
-  #   uses: ./.github/workflows/unit-test.yml
-  #   with:
-  #     path: ${{ matrix.OF.path }}
-  #   strategy:
-  #     fail-fast: false
-  #     matrix: ${{ fromJson(needs.setup_build_matrix.outputs.matrix) }}
+  unit_tests:
+    needs: [build, setup_build_matrix]
+    uses: ./.github/workflows/unit-test.yml
+    with:
+      path: ${{ matrix.OF.path }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup_build_matrix.outputs.matrix) }}
 
   integration_tests:
     needs: [build, setup_build_matrix]

--- a/.github/workflows/check_changelog.yaml
+++ b/.github/workflows/check_changelog.yaml
@@ -1,0 +1,17 @@
+name: "Pull Request Workflow"
+on:
+  pull_request:
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    # This is needed to allow skipping enforcement of the changelog in PRs with specific labels,
+    # as defined in the (optional) "skipLabels" property.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: CHANGELOG.md

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -16,6 +16,6 @@ jobs:
         fallback-style: 'Mozilla' # optional
     - name: check for todo fixme note
       run: |
-        NTODOS="$(grep -r 'TODO DONT MERGE' | wc -l)"
+        NTODOS="$(grep -r 'TODO DONT MERGE' --exclude-dir=.github | wc -l)"
         echo "Found $NTODOS TODO DONT MERGE notes" 
         ! grep -q -r "TODO DONT MERGE" --exclude-dir=.github  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# 0.5.0 (unreleased)
+- Add on device permutation functionality [PR #101](https://github.com/hpsim/OGL/pull/101) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,10 +198,6 @@ target_include_directories(
 
 target_link_libraries(OGL
     PUBLIC
-        # $ENV{FOAM_LIBBIN}/libOpenFOAM.so
-        # $ENV{FOAM_LIBBIN}/libfiniteVolume.so
-        # $ENV{FOAM_LIBBIN}/$ENV{FOAM_MPI}/libPstream.so
-        # $ENV{FOAM_LIBBIN}/libOSspecific.o
         Ginkgo::ginkgo
         stdc++fs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,14 @@ target_include_directories(
          $ENV{FOAM_SRC}/meshTools/lnInclude $ENV{FOAM_SRC}/OpenFOAM/lnInclude
          $ENV{FOAM_SRC}/OSspecific/POSIX/lnInclude ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(OGL PUBLIC Ginkgo::ginkgo stdc++fs)
+target_link_libraries(OGL
+    PUBLIC
+        # $ENV{FOAM_LIBBIN}/libOpenFOAM.so
+        # $ENV{FOAM_LIBBIN}/libfiniteVolume.so
+        # $ENV{FOAM_LIBBIN}/$ENV{FOAM_MPI}/libPstream.so
+        # $ENV{FOAM_LIBBIN}/libOSspecific.o
+        Ginkgo::ginkgo
+        stdc++fs)
 
 if(${GINKGO_WITH_OGL_EXTENSIONS})
   target_compile_definitions(OGL PRIVATE GINKGO_WITH_OGL_EXTENSIONS=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,10 @@ target_include_directories(
          $ENV{FOAM_SRC}/OSspecific/POSIX/lnInclude ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries(OGL
+    PRIVATE
+         $ENV{FOAM_LIBBIN}/libOpenFOAM.so
+         $ENV{FOAM_LIBBIN}/libfiniteVolume.so
+         $ENV{FOAM_LIBBIN}/$ENV{FOAM_MPI}/libPstream.so
     PUBLIC
         Ginkgo::ginkgo
         stdc++fs)

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -147,12 +147,12 @@ struct MatrixInitFunctor {
         gko::array<scalar> device_non_local_values{device_exec,
                                                    *non_local_coeffs.get()};
 
-        auto value_view = val_array::view(
-            device_exec, device_values.get_num_elems(), value_ptr);
+        auto value_view =
+            val_array::view(device_exec, device_values.get_size(), value_ptr);
 
-        auto non_local_view = val_array::view(
-            device_exec, device_non_local_values.get_num_elems(),
-            non_local_value_ptr);
+        auto non_local_view =
+            val_array::view(device_exec, device_non_local_values.get_size(),
+                            non_local_value_ptr);
 
         value_view = device_values;
         non_local_view = device_non_local_values;
@@ -206,7 +206,7 @@ struct MatrixInitFunctor {
             *coeffs.get());
 
         gko::device_matrix_data<scalar, label> non_local_A_data(
-            exec, gko::dim<2>(num_rows, non_local_cols->get_num_elems()),
+            exec, gko::dim<2>(num_rows, non_local_cols->get_size()),
             *non_local_rows.get(), *non_local_cols.get(),
             *non_local_coeffs.get());
 

--- a/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
+++ b/DevicePersistent/CsrMatrixWrapper/CsrMatrixWrapper.H
@@ -239,10 +239,15 @@ private:
     using dist_mtx =
         gko::experimental::distributed::Matrix<scalar, label, label>;
 
+    const objectRegistry &db_;
 
     const label verbose_;
 
     const bool export_;
+
+    const word field_name_;
+
+    const word matrix_format_;
 
     mutable PersistentBase<dist_mtx, MatrixInitFunctor> gkomatrix_;
 
@@ -260,14 +265,18 @@ public:
                   const PersistentPartition &partition,
                   const dictionary &controlDict, const word sys_matrix_name,
                   const label verbose)
-        : verbose_(verbose),
+        : db_(db),
+          verbose_(verbose),
           export_(controlDict.lookupOrDefault<Switch>("export", false)),
+          field_name_(sys_matrix_name),
+          matrix_format_(
+              controlDict.lookupOrDefault<word>("matrixFormat", "Coo")),
           gkomatrix_{
               sys_matrix_name + "_matrix", db,
               MatrixInitFunctor(
                   db, exec, partition, col_idxs, row_idxs, coeffs,
                   non_local_col_idxs, non_local_row_idxs, non_local_coeffs,
-                  controlDict.lookupOrDefault<word>("matrixFormat", "Coo"),
+                  matrix_format_,
                   controlDict.lookupOrDefault<Switch>("regenerate", false),
                   verbose_, sys_matrix_name),
               controlDict.lookupOrDefault<Switch>("updateSysMatrix", true),
@@ -281,6 +290,27 @@ public:
 
 
     bool get_export() const { return export_; }
+
+    /** Exports local and non-local matrix to processor?/<time>/.mtx files
+     */
+    void write() const
+    {
+        export_mtx(
+            field_name_,
+            gko::as<
+                gko::experimental::distributed::Matrix<scalar, label, label>>(
+                get().get())
+                ->get_local_matrix(),
+            "local", db_, matrix_format_);
+
+        export_mtx(
+            field_name_,
+            gko::as<
+                gko::experimental::distributed::Matrix<scalar, label, label>>(
+                get().get())
+                ->get_non_local_matrix(),
+            "non_local", db_, matrix_format_);
+    }
 };
 
 }  // namespace Foam

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -98,7 +98,6 @@ struct ExecutorInitFunctor {
                        "with HIP backend enabled."
                     << abort(FatalError);
             };
-
             auto ret = gko::share(gko::HipExecutor::create(
                 device_id_ % gko::HipExecutor::get_num_devices(), host_exec,
                 true));

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -77,8 +77,7 @@ struct ExecutorInitFunctor {
             };
 
             return gko::share(gko::CudaExecutor::create(
-                device_id_ % gko::CudaExecutor::get_num_devices(), host_exec,
-                false, gko::allocation_mode::device));
+                device_id_ % gko::CudaExecutor::get_num_devices(), host_exec));
         }
         if (executor_name_ == "dpcpp") {
             if (version.dpcpp_version.tag == not_compiled_tag) {
@@ -99,8 +98,8 @@ struct ExecutorInitFunctor {
                     << abort(FatalError);
             };
             auto ret = gko::share(gko::HipExecutor::create(
-                device_id_ % gko::HipExecutor::get_num_devices(), host_exec,
-                true));
+                device_id_ % gko::HipExecutor::get_num_devices(), host_exec
+                ));
             return ret;
         }
         if (executor_name_ == "omp") {

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -98,8 +98,7 @@ struct ExecutorInitFunctor {
                     << abort(FatalError);
             };
             auto ret = gko::share(gko::HipExecutor::create(
-                device_id_ % gko::HipExecutor::get_num_devices(), host_exec
-                ));
+                device_id_ % gko::HipExecutor::get_num_devices(), host_exec));
             return ret;
         }
         if (executor_name_ == "omp") {

--- a/DevicePersistent/Vector/Vector.H
+++ b/DevicePersistent/Vector/Vector.H
@@ -114,6 +114,10 @@ class PersistentVector
     using dist_vec = gko::experimental::distributed::Vector<scalar>;
     using vec = gko::matrix::Dense<scalar>;
 
+    const objectRegistry &db_;
+
+    const word name_;
+
     const T *memory_;
 
     const PersistentPartition partition_;
@@ -150,35 +154,16 @@ public:
               VectorInitFunctor<T>(exec, name, partition, memory, verbose,
                                    init_on_device),
               update, verbose),
+	  db_(db),
+	  name_(name),
           memory_(memory),
           partition_(partition),
           exec_(exec),
           update_(update)
     {}
 
-    // label get_global_size() const { return partition_.size(); }
-
-    bool get_update() const { return update_; }
-
-    T *get_data() const { return this->get_persistent_object()->get_data(); }
-
-    void set_data(T *data)
-    {
-        this->get_persistent_object()->get_data() = data;
-    };
-
-    const T *get_const_data() const
-    {
-        return this->get_persistent_object()->get_const_data();
-    };
-
-
-    std::shared_ptr<gko::experimental::distributed::Vector<T>> get_vector()
-        const
-    {
-        return this->get_persistent_object();
-    }
-
+    /** Copies the content of the distributed vector back to the original source
+     **/
     void copy_back()
     {
         const auto local_size = partition_.get_local_size();
@@ -204,7 +189,38 @@ public:
         to_view = host_buffer_view;
     }
 
+    /** Writes the content of the distributed vector to disk
+     **
+     ** Data is stored as .mtx file under processor?/<time>/<name_>.mtx
+     **/
+    void write() const {
+        export_vec(name_, get_vector()->get_local_vector(), db_);
+    }
+
+    // getter and setter
+
+    bool get_update() const { return update_; }
+
+    T *get_data() const { return this->get_persistent_object()->get_data(); }
+
+    void set_data(T *data)
+    {
+        this->get_persistent_object()->get_data() = data;
+    };
+
+    const T *get_const_data() const
+    {
+        return this->get_persistent_object()->get_const_data();
+    };
+
     const ExecutorHandler &get_exec_handler() const { return exec_; }
+
+    std::shared_ptr<gko::experimental::distributed::Vector<T>> get_vector()
+        const
+    {
+        return this->get_persistent_object();
+    }
+
 };
 
 }  // namespace Foam

--- a/DevicePersistent/Vector/Vector.H
+++ b/DevicePersistent/Vector/Vector.H
@@ -154,8 +154,8 @@ public:
               VectorInitFunctor<T>(exec, name, partition, memory, verbose,
                                    init_on_device),
               update, verbose),
-	  db_(db),
-	  name_(name),
+          db_(db),
+          name_(name),
           memory_(memory),
           partition_(partition),
           exec_(exec),
@@ -193,7 +193,8 @@ public:
      **
      ** Data is stored as .mtx file under processor?/<time>/<name_>.mtx
      **/
-    void write() const {
+    void write() const
+    {
         export_vec(name_, get_vector()->get_local_vector(), db_);
     }
 
@@ -220,7 +221,6 @@ public:
     {
         return this->get_persistent_object();
     }
-
 };
 
 }  // namespace Foam

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -357,8 +357,7 @@ HostMatrixWrapper<MatrixType>::collect_cells_on_interface(
 
     label startOfRequests = Pstream::nRequests();
     interface_iterator<processorLduInterface>(
-        interfaces, [&](label, const label interface_size,
-                        const processorLduInterface &patch,
+        interfaces, [&](label, const label, const processorLduInterface &,
                         const lduInterfaceField *iface) {
             const processorLduInterface &pldui =
                 refCast<const processorLduInterface>(iface->interface());
@@ -399,8 +398,6 @@ HostMatrixWrapper<MatrixType>::collect_cells_on_interface(
 
         for (label cellI = 0; cellI < interface_size; cellI++) {
             auto local_row = face_cells[cellI];
-            auto global_row = global_row_index_.toGlobal(
-                neighbProcNo, otherSide_tmp()[cellI]);
             non_local_idxs.push_back({interface_ctr, local_row, uniqueIdCtr});
             uniqueIdCtr++;
             interface_ctr += 1;
@@ -573,8 +570,7 @@ void HostMatrixWrapper<MatrixType>::init_local_sparsity_pattern(
 template <class MatrixType>
 void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
     const lduInterfaceFieldPtrsList &interfaces,
-    const FieldField<Field, scalar> &interfaceBouCoeffs,
-    const objectRegistry &db) const
+    const FieldField<Field, scalar> &interfaceBouCoeffs) const
 {
     auto ref_exec = exec_.get_ref_exec();
     auto upper = this->matrix().upper();

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -647,9 +647,8 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
         // TODO DONT MERGE this needs a new implementation
         if (!permutation_stored_) {
             P_ = gko::share(gko::matrix::Permutation<label>::create(
-                ref_exec,
-                gko::dim<2>{local_matrix_w_interfaces_nnz_},
-                permute);
+                ref_exec, gko::dim<2>{local_matrix_w_interfaces_nnz_},
+                permute));
             const fileName path = permutation_matrix_name_;
             // this leaks po to create a persistent object
             auto po =

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -602,6 +602,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
     auto ref_exec = exec_.get_ref_exec();
     auto upper = this->matrix().upper();
     auto lower = this->matrix().lower();
+    auto diag = this->matrix().diag();
 
     label diag_nnz = diag.size();
     bool is_symmetric{this->matrix().symmetric()};

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -431,7 +431,7 @@ void HostMatrixWrapper<MatrixType>::init_non_local_sparsity_pattern(
     auto cols = non_local_sparsity_.col_idxs_.get_data();
     auto permute = non_local_sparsity_.ldu_mapping_.get_data();
 
-    // Sorting of the interfaces is still needed since we can we have 
+    // Sorting of the interfaces is still needed since we can we have
     // multiple interfaces using the same rows/send_idxs
     // if the resulting non_local_matrix is not in row major order
     // we might get non converging solvers on GPU devices

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -110,7 +110,7 @@ HostMatrixWrapper<MatrixType>::HostMatrixWrapper(
     if (!local_coeffs_.get_stored() || local_coeffs_.get_update()) {
         TIME_WITH_FIELDNAME(
             verbose_, update_local_matrix_data, this->fieldName(),
-            update_local_matrix_data(interfaces, interfaceBouCoeffs, db);)
+            update_local_matrix_data(interfaces, interfaceBouCoeffs);)
         TIME_WITH_FIELDNAME(
             verbose_, update_non_local_matrix_data, this->fieldName(),
             update_non_local_matrix_data(interfaces, interfaceBouCoeffs);)

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -71,7 +71,7 @@ HostMatrixWrapper<MatrixType>::HostMatrixWrapper(
           verbose_,
           true,              // needs to be updated
           !reorder_on_copy_  // whether to init on device
-                             // if reoderOnHost is selected, the array needs
+                             // if reorderOnHost is selected, the array needs
                              // to be initialized on the host
       },
       non_local_matrix_nnz_(count_interface_nnz(interfaces, true)),
@@ -147,7 +147,7 @@ HostMatrixWrapper<MatrixType>::HostMatrixWrapper(
           verbose_,
           true,              // needs to be updated
           !reorder_on_copy_  // whether to init on device
-                             // if reoderOnHost is selected, the array needs
+                             // if reorderOnHost is selected, the array needs
                              // to be initialized on the host
       },
       non_local_matrix_nnz_(),

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -614,7 +614,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
             }
         }
     } else {
-        // TODO 
+        // TODO
         // - this should be moved to separate function to avoid making this
         // too long
 

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -652,7 +652,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
         }
     } else {
         // TODO DONT MERGE this needs a new implementation
-        auto contiguos = vec::create(
+        auto contiguous = vec::create(
             ref_exec,
             gko::dim<2>((gko::dim<2>::dimension_type)nnz_local_matrix_, 1));
 

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -615,7 +615,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
         1);
 
     // TODO this does not work for Ell
-    const auto permute = local_sparsity_.ldu_mapping_.get_data();
+    auto permute = local_sparsity_.ldu_mapping_.get_data();
     auto dense = dense_vec->get_values();
 
     if (reorder_on_copy_) {
@@ -646,9 +646,9 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
     } else {
         // TODO DONT MERGE this needs a new implementation
         if (!permutation_stored_) {
+            const auto permute_array = local_sparsity_.ldu_mapping_.get_array();
             P_ = gko::share(gko::matrix::Permutation<label>::create(
-                ref_exec, gko::dim<2>{local_matrix_w_interfaces_nnz_},
-                permute));
+                ref_exec, gko::array<label>(*permute_array.get())));
             const fileName path = permutation_matrix_name_;
             // this leaks po to create a persistent object
             auto po =

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -262,7 +262,8 @@ HostMatrixWrapper<MatrixType>::create_communication_pattern(
     // temp map, mapping from neighbour rank interface cells
     std::map<label, std::vector<label>> interface_cell_map{};
 
-    //
+    // iterate all interfaces, count number of neighbour procs
+    // and store rows to send to neighbour procs
     label n_procs = 0;
     interface_iterator<processorFvPatch>(
         interfaces,
@@ -274,23 +275,13 @@ HostMatrixWrapper<MatrixType>::create_communication_pattern(
             neighbour_procs.push_back(
                 std::pair<label, label>{neighbProcNo, interface_size});
 
-            // TODO DONT MERGE For now this can be simplified since
+            // For now this can be simplified since
             // we dont have multiple interfaces between one processor
-            auto search = interface_cell_map.find(neighbProcNo);
-            if (search == interface_cell_map.end()) {
-                n_procs++;
-                interface_cell_map.insert(std::pair{
-                    neighbProcNo,
-                    std::vector<label>(face_cells.begin(), face_cells.end())});
-            } else {
-                auto cur_face_cells = interface_cell_map[neighbProcNo];
-                // TODO reserve current size + interface_size
-                cur_face_cells.reserve(interface_size);
-                for (auto face_cell : face_cells) {
-                    cur_face_cells.push_back(face_cell);
-                }
-                interface_cell_map[neighbProcNo] = cur_face_cells;
-            }
+            // auto search = interface_cell_map.find(neighbProcNo);
+            n_procs++;
+            interface_cell_map.insert(std::pair{
+                neighbProcNo,
+                std::vector<label>(face_cells.begin(), face_cells.end())});
         });
 
 

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -652,6 +652,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
         }
     } else {
         // TODO DONT MERGE this needs a new implementation
+
         // copy upper
         auto upper = this->matrix().upper();
         auto u_host_view =

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -263,6 +263,7 @@ HostMatrixWrapper<MatrixType>::create_communication_pattern(
     std::map<label, std::vector<label>> interface_cell_map{};
 
     //
+    label n_procs = 0;
     interface_iterator<processorFvPatch>(
         interfaces,
         [&](label, const label interface_size, const processorFvPatch &patch,
@@ -273,8 +274,11 @@ HostMatrixWrapper<MatrixType>::create_communication_pattern(
             neighbour_procs.push_back(
                 std::pair<label, label>{neighbProcNo, interface_size});
 
+            // TODO DONT MERGE For now this can be simplified since
+            // we dont have multiple interfaces between one processor
             auto search = interface_cell_map.find(neighbProcNo);
             if (search == interface_cell_map.end()) {
+                n_procs++;
                 interface_cell_map.insert(std::pair{
                     neighbProcNo,
                     std::vector<label>(face_cells.begin(), face_cells.end())});

--- a/HostMatrix/HostMatrix.C
+++ b/HostMatrix/HostMatrix.C
@@ -614,7 +614,7 @@ void HostMatrixWrapper<MatrixType>::update_local_matrix_data(
             }
         }
     } else {
-        // TODO DONT MERGE this needs a new implementation
+        // TODO 
         // - this should be moved to separate function to avoid making this
         // too long
 

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -53,7 +53,8 @@ struct PersistentSparsityPattern {
         size,
         verbose,
         false,  // For now we assume columns and rows to be constant
-        false   // same as for values, leave on device
+        false   // we don't init on device since the indices are written using the pointer
+		// to the data
     },
     row_idxs_{
         fieldName + "_rows",
@@ -62,7 +63,7 @@ struct PersistentSparsityPattern {
         size,
         verbose,
         false,  // For now we assume columns and rows to be constant
-        false   // same as for values, leave on device
+        false   // same as for cols don't init on device
     },
     ldu_mapping_{
         fieldName + "_ldu_map",
@@ -71,7 +72,7 @@ struct PersistentSparsityPattern {
         size,
         verbose,
         false,
-        false
+        false // same as for rows and cols dont init on device
     }
     {}
 
@@ -282,6 +283,7 @@ private:
 
     mutable PersistentSparsityPattern local_sparsity_;
 
+    // matrix coefficiens
     mutable PersistentArray<scalar> local_coeffs_;
 
     // non-local indices

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -287,7 +287,7 @@ private:
 
     mutable PersistentSparsityPattern local_sparsity_;
 
-    // matrix coefficiens
+    // matrix coefficients
     mutable PersistentArray<scalar> local_coeffs_;
 
     // non-local indices

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -385,8 +385,7 @@ private:
      **/
     void update_local_matrix_data(
         const lduInterfaceFieldPtrsList &interfaces,
-        const FieldField<Field, scalar> &interfaceBouCoeffs,
-        const objectRegistry &db) const;
+        const FieldField<Field, scalar> &interfaceBouCoeffs) const;
 
     /** Copies the interface matrix coefficients to non_local_coeffs without
     ** changing or reinstantiating the sparsity pattern.

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -54,7 +54,7 @@ struct PersistentSparsityPattern {
         verbose,
         false,  // For now we assume columns and rows to be constant
         false   // we don't init on device since the indices are written using the pointer
-		// to the data
+                // to the data
     },
     row_idxs_{
         fieldName + "_rows",
@@ -104,14 +104,18 @@ const lduInterfaceField *interface_getter(
     const lduInterfaceFieldPtrsList &interfaces, const label i);
 
 /** Write contiguous row and col indices from OpenFOAM lower and upper indices
- **
+ ** For details on the lower triangular based indexing see
+ ** https://openfoamwiki.net/index.php/OpenFOAM_guide/Matrices_in_OpenFOA
+ ** Note that the order of the indices are depicted wrong on the wiki
+ ** In general the upper triangular matrix is traversed in row major
+ ** and the lower triangular matrix in column major order.
  **
  ** @param nrows number of rows
  ** @param upper_nnz number of non zeros in the upper triangular matrix
  ** @param is_symmetric whether matrix is symmetric, in the symmetric case
  ** the lower elements indices in the permute array are computed differently
- ** @param upper pointer to array of
- ** @param lower pointer to rows array
+ ** @param upper pointer to OFs rows array
+ ** @param lower pointer to OFs cols array
  ** @param rows pointer to rows array
  ** @param cols pointer to columns array
  ** @param permute pointer to permuter array
@@ -334,8 +338,8 @@ private:
 
 
     /** Iterates all interfaces and counts the number of unique neighbour
-     **processors and number of interfaces in total for this processor
-     ** and collects all interface cells of this rank
+     ** processors and number of interfaces in total for this processor
+     ** and collects all interface cells of this rank.
      **
      ** @param interfaces The list of interfaces for the search
      ** @return the CommunicationPattern

--- a/HostMatrix/HostMatrix.H
+++ b/HostMatrix/HostMatrix.H
@@ -375,11 +375,12 @@ private:
     /** Copies the LDU matrix coefficients to local_coeffs without changing or
      ** reinstantiating the sparsity pattern.
      ** This uses the local_sparsity_.ldu_mapping to permute the data already
-     ** on the host to be in row major order
+     ** on the host or device to be in row major order.
      **/
     void update_local_matrix_data(
         const lduInterfaceFieldPtrsList &interfaces,
-        const FieldField<Field, scalar> &interfaceBouCoeffs) const;
+        const FieldField<Field, scalar> &interfaceBouCoeffs,
+        const objectRegistry &db) const;
 
     /** Copies the interface matrix coefficients to non_local_coeffs without
     ** changing or reinstantiating the sparsity pattern.

--- a/HostMatrix/HostMatrixFreeFunctions.C
+++ b/HostMatrix/HostMatrixFreeFunctions.C
@@ -103,7 +103,6 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
                          const label *lower, label *rows, label *cols,
                          label *permute)
 {
-    std::cout << "init_local_sparsity\n";
     // for OpenFOAMs addressing see
     // https://openfoamwiki.net/index.php/OpenFOAM_guide/Matrices_in_OpenFOAM
     // Note that the face order in the wiki seems to be wrong. Entries are 

--- a/HostMatrix/HostMatrixFreeFunctions.C
+++ b/HostMatrix/HostMatrixFreeFunctions.C
@@ -148,6 +148,8 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
     label element_ctr = 0;
     label upper_ctr = 0;
     label lower_ctr = 0;
+    label lower_size = tmp_lower.size();
+    label upper_size = tmp_upper.size();
     auto [row_lower, col_lower, faceI_lower] = tmp_lower[0];
     auto [row_upper, col_upper, faceI_upper] = tmp_upper[0];
     for (label row = 0; row < nrows; row++) {
@@ -159,7 +161,7 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
                 (is_symmetric) ? faceI_lower : upper_nnz + faceI_lower;
             element_ctr++;
             lower_ctr++;
-            if (lower_ctr >= tmp_lower.size()) {
+            if (lower_ctr >= lower_size) {
                 break;
             }
             auto [tmp_row_lower, tmp_col_lower, tmp_faceI_lower] =
@@ -182,7 +184,7 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
             permute[element_ctr] = faceI_upper;
             element_ctr++;
             upper_ctr++;
-            if (upper_ctr >= tmp_upper.size()) {
+            if (upper_ctr >= upper_size) {
                 break;
             }
             auto [tmp_row_upper, tmp_col_upper, tmp_faceI_upper] =

--- a/HostMatrix/HostMatrixFreeFunctions.C
+++ b/HostMatrix/HostMatrixFreeFunctions.C
@@ -105,7 +105,7 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
 {
     // for OpenFOAMs addressing see
     // https://openfoamwiki.net/index.php/OpenFOAM_guide/Matrices_in_OpenFOAM
-    // Note that the face order in the wiki seems to be wrong. Entries are 
+    // Note that the face order in the wiki seems to be wrong. Entries are
     // stored such that upper rows are monotonic ascending
     // upper - rows of lower triangular matrix
     // lower - columns of lower triangular matrix
@@ -156,13 +156,14 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
             rows[element_ctr] = row_lower;
             cols[element_ctr] = col_lower;
             permute[element_ctr] =
-                (is_symmetric) ? faceI_lower :  upper_nnz + faceI_lower;
+                (is_symmetric) ? faceI_lower : upper_nnz + faceI_lower;
             element_ctr++;
             lower_ctr++;
             if (lower_ctr >= tmp_lower.size()) {
                 break;
             }
-            auto [ tmp_row_lower, tmp_col_lower, tmp_faceI_lower ] = tmp_lower[lower_ctr];
+            auto [tmp_row_lower, tmp_col_lower, tmp_faceI_lower] =
+                tmp_lower[lower_ctr];
             row_lower = tmp_row_lower;
             col_lower = tmp_col_lower;
             faceI_lower = tmp_faceI_lower;
@@ -175,7 +176,7 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
         element_ctr++;
 
         // check if we have any upper elements to insert
-        while (row_upper == row ) {
+        while (row_upper == row) {
             rows[element_ctr] = row_upper;
             cols[element_ctr] = col_upper;
             permute[element_ctr] = faceI_upper;
@@ -184,7 +185,8 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
             if (upper_ctr >= tmp_upper.size()) {
                 break;
             }
-            auto [ tmp_row_upper, tmp_col_upper, tmp_faceI_upper ] = tmp_upper[upper_ctr];
+            auto [tmp_row_upper, tmp_col_upper, tmp_faceI_upper] =
+                tmp_upper[upper_ctr];
             row_upper = tmp_row_upper;
             col_upper = tmp_col_upper;
             faceI_upper = tmp_faceI_upper;

--- a/HostMatrix/HostMatrixFreeFunctions.C
+++ b/HostMatrix/HostMatrixFreeFunctions.C
@@ -97,23 +97,76 @@ void non_symmetric_update(const label total_nnz, const label upper_nnz,
     }
 }
 
+
 void init_local_sparsity(const label nrows, const label upper_nnz,
                          const bool is_symmetric, const label *upper,
                          const label *lower, label *rows, label *cols,
                          label *permute)
 {
+    std::cout << "init_local_sparsity\n";
+    // for OpenFOAMs addressing see
+    // https://openfoamwiki.net/index.php/OpenFOAM_guide/Matrices_in_OpenFOAM
+    // Note that the face order in the wiki seems to be wrong. Entries are 
+    // stored such that upper rows are monotonic ascending
+    // upper - rows of lower triangular matrix
+    // lower - columns of lower triangular matrix
     label after_neighbours = (is_symmetric) ? upper_nnz : 2 * upper_nnz;
+
+    // first pass order elements row wise
+    // scan through all faces
+    std::vector<std::tuple<label, label, label>> tmp_upper;
+    tmp_upper.reserve(upper_nnz);
+    for (label faceI = 0; faceI < upper_nnz; faceI++) {
+        const label col = upper[faceI];
+        const label row = lower[faceI];
+        tmp_upper.emplace_back(row, col, faceI);
+    }
+
+    std::sort(tmp_upper.begin(), tmp_upper.end(),
+              [&](const auto &a, const auto &b) {
+                  auto [row_a, col_a, faceI_a] = a;
+                  auto [row_b, col_b, faceI_b] = b;
+                  return std::tie(row_a, col_a) < std::tie(row_b, col_b);
+              });
+
+    std::vector<std::tuple<label, label, label>> tmp_lower;
+    tmp_lower.reserve(upper_nnz);
+    for (label faceI = 0; faceI < upper_nnz; faceI++) {
+        const label col = lower[faceI];
+        const label row = upper[faceI];
+        tmp_lower.emplace_back(row, col, faceI);
+    }
+
+    std::sort(tmp_lower.begin(), tmp_lower.end(),
+              [&](const auto &a, const auto &b) {
+                  auto [row_a, col_a, faceI_a] = a;
+                  auto [row_b, col_b, faceI_b] = b;
+                  return std::tie(row_a, col_a) < std::tie(row_b, col_b);
+              });
+
+    // now we have tmp_upper and tmp_lower in row order
+
     label element_ctr = 0;
     label upper_ctr = 0;
-    std::vector<std::vector<std::pair<label, label>>> lower_stack(upper_nnz);
+    label lower_ctr = 0;
+    auto [row_lower, col_lower, faceI_lower] = tmp_lower[0];
+    auto [row_upper, col_upper, faceI_upper] = tmp_upper[0];
     for (label row = 0; row < nrows; row++) {
-        // add lower elements
-        // for now just scan till current upper ctr
-        for (const auto &[stored_upper_ctr, col] : lower_stack[row]) {
-            rows[element_ctr] = row;
-            cols[element_ctr] = col;
-            permute[element_ctr] = stored_upper_ctr;
+        // check if we have any lower elements to insert
+        while (row_lower == row) {
+            rows[element_ctr] = row_lower;
+            cols[element_ctr] = col_lower;
+            permute[element_ctr] =
+                (is_symmetric) ? faceI_lower :  upper_nnz + faceI_lower;
             element_ctr++;
+            lower_ctr++;
+            if (lower_ctr >= tmp_lower.size()) {
+                break;
+            }
+            auto [ tmp_row_lower, tmp_col_lower, tmp_faceI_lower ] = tmp_lower[lower_ctr];
+            row_lower = tmp_row_lower;
+            col_lower = tmp_col_lower;
+            faceI_lower = tmp_faceI_lower;
         }
 
         // add diagonal elements
@@ -122,27 +175,22 @@ void init_local_sparsity(const label nrows, const label upper_nnz,
         permute[element_ctr] = after_neighbours + row;
         element_ctr++;
 
-        // add upper elements
-        // these are the transpose of the lower elements which are stored in
-        // row major order.
-        label row_upper = lower[upper_ctr];
-        while (upper_ctr < upper_nnz && row_upper == row) {
-            const label col_upper = upper[upper_ctr];
-
+        // check if we have any upper elements to insert
+        while (row_upper == row ) {
             rows[element_ctr] = row_upper;
             cols[element_ctr] = col_upper;
-
-            // insert into lower_stack
-            lower_stack[col_upper].emplace_back(
-                (is_symmetric) ? upper_ctr : upper_ctr + upper_nnz, row_upper);
-            permute[element_ctr] = upper_ctr;
-
+            permute[element_ctr] = faceI_upper;
             element_ctr++;
             upper_ctr++;
-            row_upper = lower[upper_ctr];
+            if (upper_ctr >= tmp_upper.size()) {
+                break;
+            }
+            auto [ tmp_row_upper, tmp_col_upper, tmp_faceI_upper ] = tmp_upper[upper_ctr];
+            row_upper = tmp_row_upper;
+            col_upper = tmp_col_upper;
+            faceI_upper = tmp_faceI_upper;
         }
     }
 }
-
 
 }  // namespace Foam

--- a/Preconditioner/Preconditioner.H
+++ b/Preconditioner/Preconditioner.H
@@ -182,8 +182,8 @@ public:
             // iterative refinement method.
             auto precond_factory =
                 gko::preconditioner::Ilu<ir, ir>::build()
-                    .with_l_solver_factory(gko::clone(trisolve_factory))
-                    .with_u_solver_factory(gko::clone(trisolve_factory))
+                    .with_l_solver(gko::clone(trisolve_factory))
+                    .with_u_solver(gko::clone(trisolve_factory))
                     .on(device_exec);
 
             auto factorization_factory =

--- a/StoppingCriterion/StoppingCriterion.C
+++ b/StoppingCriterion/StoppingCriterion.C
@@ -38,7 +38,7 @@ void StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_Axref_dist(
     xAvg->move_to(xAvg_host);
     auto xAvg_vec = gko::share(
         dist_vec::create(device_exec, x->get_communicator(),
-                         gko::dim<2>{global_size}, gko::dim<2>{local_size}));
+                         gko::dim<2>{global_size,1}, gko::dim<2>{local_size,1}));
     xAvg_vec->fill(xAvg_host->at(0));
 
     gkomatrix->apply(xAvg_vec.get(), res.get());

--- a/StoppingCriterion/StoppingCriterion.C
+++ b/StoppingCriterion/StoppingCriterion.C
@@ -21,7 +21,152 @@ License
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
-namespace Foam {}  // namespace Foam
+namespace Foam {
+
+void StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_Axref_dist(
+    size_t global_size, size_t local_size,
+    std::shared_ptr<const gko::Executor> device_exec,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x, std::shared_ptr<dist_vec> res) const
+{
+    auto xAvg =
+        gko::initialize<gko::matrix::Dense<scalar>>(1, {0}, device_exec);
+    x->compute_mean(xAvg.get());
+
+    auto xAvg_host = gko::initialize<gko::matrix::Dense<scalar>>(
+        1, {0}, device_exec->get_master());
+    xAvg->move_to(xAvg_host);
+    auto xAvg_vec = gko::share(
+        dist_vec::create(device_exec, x->get_communicator(),
+                         gko::dim<2>{global_size}, gko::dim<2>{local_size}));
+    xAvg_vec->fill(xAvg_host->at(0));
+
+    gkomatrix->apply(xAvg_vec.get(), res.get());
+}
+
+scalar
+StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_normfactor_dist(
+    std::shared_ptr<const gko::Executor> device_exec, const dist_vec *r,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x, std::shared_ptr<const dist_vec> b) const
+{
+    // TODO store colA vector
+    auto comm = x->get_communicator();
+
+    gko::dim<2> local_size = x->get_local_vector()->get_size();
+    gko::dim<2> global_size = x->get_size();
+
+    auto Axref = gko::share(
+        dist_vec::create(device_exec, comm, global_size, local_size));
+
+    compute_Axref_dist(global_size[0], local_size[0], device_exec, gkomatrix, x,
+                       Axref);
+
+    auto unity =
+        gko::initialize<gko::matrix::Dense<scalar>>(1, {1.0}, device_exec);
+
+    auto b_sub_xstar = b->clone();
+    b_sub_xstar->sub_scaled(unity.get(), Axref.get());
+
+    auto norm_part2 = b_sub_xstar->compute_absolute();
+
+    b_sub_xstar->sub_scaled(unity.get(), r);
+    b_sub_xstar->compute_absolute_inplace();
+
+    b_sub_xstar->add_scaled(unity.get(), norm_part2.get());
+    auto res = vec::create(device_exec, gko::dim<2>{1});
+    b_sub_xstar->compute_norm1(res.get());
+
+    auto res_host = vec::create(device_exec->get_master(), gko::dim<2>{1});
+    res_host->copy_from(res.get());
+
+    return res_host->get_values()[0] + SMALL;
+}
+
+bool StoppingCriterion::OpenFOAMDistStoppingCriterion::check_impl(
+    gko::uint8 stoppingId, bool setFinalized,
+    gko::array<gko::stopping_status> *stop_status, bool *one_changed,
+    const Criterion::Updater &updater)
+{
+    // Dont check residual norm before minIter is reached
+    if (*(parameters_.iter) > 0 &&
+        *(parameters_.iter) < parameters_.openfoam_minIter) {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    // Only check residual for every frequency iteration
+    if (*(parameters_.iter) % parameters_.frequency != 0) {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    auto start_eval = std::chrono::steady_clock::now();
+    const auto exec = this->get_executor();
+
+    auto *dense_r = gko::as<dist_vec>(updater.residual_);
+    auto norm1 = vec::create(exec, gko::dim<2>{1});
+    dense_r->compute_norm1(norm1.get());
+    auto norm1_host = vec::create(exec->get_master(), gko::dim<2>{1});
+    norm1_host->copy_from(norm1.get());
+    scalar residual_norm = norm1_host->at(0);
+
+    bool result = false;
+
+    // Store initial residual
+    if (*(parameters_.iter) == 0) {
+        //
+        if (eval_norm_factor_) {
+            norm_factor_ =
+                compute_normfactor_dist(exec, dense_r, parameters_.gkomatrix,
+                                        parameters_.x, parameters_.b);
+        }
+
+        *(parameters_.init_residual_norm) = residual_norm / norm_factor_;
+    }
+
+    residual_norm /= norm_factor_;
+
+    if (parameters_.export_res) {
+        parameters_.residual_norms->at(*(parameters_.iter)) = residual_norm;
+    }
+
+    *(parameters_.residual_norm) = residual_norm;
+
+    scalar init_residual = *(parameters_.init_residual_norm);
+
+    // stop if maximum number of iterations was reached
+    if (*(parameters_.iter) >= parameters_.openfoam_maxIter) {
+        result = true;
+    }
+    // check if absolute tolerance is hit
+    if (residual_norm < parameters_.openfoam_absolute_tolerance) {
+        result = true;
+    }
+    // check if relative tolerance is hit
+    if (parameters_.openfoam_relative_tolerance > 0 &&
+        residual_norm <
+            parameters_.openfoam_relative_tolerance * init_residual) {
+        result = true;
+    }
+
+    if (result) {
+        this->set_all_statuses(stoppingId, setFinalized, stop_status);
+        *one_changed = true;
+    }
+
+    *(parameters_.iter) += 1;
+
+    auto end_eval = std::chrono::steady_clock::now();
+    *(parameters_.time) = std::chrono::duration_cast<std::chrono::microseconds>(
+                              end_eval - start_eval)
+                              .count() /
+                          1.0;
+    return result;
+}
+
+
+}  // namespace Foam
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //

--- a/StoppingCriterion/StoppingCriterion.C
+++ b/StoppingCriterion/StoppingCriterion.C
@@ -36,9 +36,9 @@ void StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_Axref_dist(
     auto xAvg_host = gko::initialize<gko::matrix::Dense<scalar>>(
         1, {0}, device_exec->get_master());
     xAvg->move_to(xAvg_host);
-    auto xAvg_vec = gko::share(
-        dist_vec::create(device_exec, x->get_communicator(),
-                         gko::dim<2>{global_size,1}, gko::dim<2>{local_size,1}));
+    auto xAvg_vec = gko::share(dist_vec::create(
+        device_exec, x->get_communicator(), gko::dim<2>{global_size, 1},
+        gko::dim<2>{local_size, 1}));
     xAvg_vec->fill(xAvg_host->at(0));
 
     gkomatrix->apply(xAvg_vec.get(), res.get());

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -200,7 +200,9 @@ public:
           adapt_minIter_(
               controlDict.lookupOrDefault<Switch>("adaptMinIter", true)),
           normalised_res_norms_(gko::share(vec::create(
-              gko::ReferenceExecutor::create(), gko::dim<2>{maxIter_, 1}))),
+              gko::ReferenceExecutor::create(),
+              gko::dim<2>{static_cast<gko::dim<2>::dimension_type>(maxIter_),
+                          1}))),
           init_normalised_res_norm_(0),
           normalised_res_norm_(0),
           iter_(0),

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -100,167 +100,32 @@ class StoppingCriterion {
 
         GKO_ENABLE_BUILD_METHOD(Factory);
 
-        // protected:
-        /* Compute the SPMV of A with x_ref
-         *
-         *
+        /* Compute the SpMV of A with x_ref, where x_ref is a vector containing
+         * the average of x in every row. This is needed to initialise the
+         * normfactor in the first iteration.
          *  */
         void compute_Axref_dist(
             size_t global_size, size_t local_size,
             std::shared_ptr<const gko::Executor> device_exec,
             std::shared_ptr<const gko::LinOp> gkomatrix,
-            std::shared_ptr<dist_vec> x, std::shared_ptr<dist_vec> res) const
-        {
-            auto xAvg = gko::initialize<gko::matrix::Dense<scalar>>(
-                1, {0}, device_exec);
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<dist_vec> res) const;
 
-            x->compute_mean(xAvg.get());
-
-#ifdef GINKGO_WITH_OGL_EXTENSIONS
-            gkomatrix->compute_column_vector_sum(res.get());
-            res->scale(xAvg.get());
-#else
-            // if column vector sum is not available use dot product
-            auto xAvg_vec = gko::share(dist_vec::create(
-                device_exec, x->get_communicator(), gko::dim<2>{global_size, 1},
-                gko::dim<2>{local_size, 1}));
-            xAvg_vec->fill(1.0);
-            xAvg_vec->scale(xAvg.get());
-
-            gkomatrix->apply(xAvg_vec.get(), res.get());
-#endif
-        }
-
-
+        /* Compute the normfactor ie || Ax - x* || + || b - x* ||
+         * or rewritten as || r - ( b - x* ) || + || (b - x*) ||
+         *  */
         scalar compute_normfactor_dist(
             std::shared_ptr<const gko::Executor> device_exec, const dist_vec *r,
             std::shared_ptr<const gko::LinOp> gkomatrix,
-            std::shared_ptr<dist_vec> x,
-            std::shared_ptr<const dist_vec> b) const
-        {
-            // SIMPLE_TIME(verbose_, compute_col_sum_A, [=]() {
-            // computes        || Ax - x* ||        + || b - x* ||
-            // or rewritten as || r - ( b - x* ) || + || (b - x*) ||
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<const dist_vec> b) const;
 
-            // TODO store colA vector
-            auto comm = x->get_communicator();
-
-            gko::dim<2> local_size = x->get_local_vector()->get_size();
-            gko::dim<2> global_size = x->get_size();
-
-            auto Axref = gko::share(
-                dist_vec::create(device_exec, comm, global_size, local_size));
-
-            compute_Axref_dist(global_size[0], local_size[0], device_exec,
-                               gkomatrix, x, Axref);
-
-            auto unity = gko::initialize<gko::matrix::Dense<scalar>>(
-                1, {1.0}, device_exec);
-
-            auto b_sub_xstar = b->clone();
-            b_sub_xstar->sub_scaled(unity.get(), Axref.get());
-
-            auto norm_part2 = b_sub_xstar->compute_absolute();
-
-            b_sub_xstar->sub_scaled(unity.get(), r);
-            b_sub_xstar->compute_absolute_inplace();
-
-            b_sub_xstar->add_scaled(unity.get(), norm_part2.get());
-            auto res = vec::create(device_exec, gko::dim<2>{1, 1});
-            b_sub_xstar->compute_norm1(res.get());
-
-            auto res_host =
-                vec::create(device_exec->get_master(), gko::dim<2>{1, 1});
-            res_host->copy_from(res.get());
-
-            return res_host->get_values()[0] + SMALL;
-        }
-
+        /* Implementation of the residual norm check
+         *  */
         bool check_impl(gko::uint8 stoppingId, bool setFinalized,
                         gko::array<gko::stopping_status> *stop_status,
                         bool *one_changed,
-                        const Criterion::Updater &updater) override
-        {
-            auto start_eval = std::chrono::steady_clock::now();
-            if (*(parameters_.iter) > 0 &&
-                *(parameters_.iter) < parameters_.openfoam_minIter) {
-                *(parameters_.iter) += 1;
-                return false;
-            }
-
-            const auto exec = this->get_executor();
-
-            if (*(parameters_.iter) % parameters_.frequency != 0) {
-                *(parameters_.iter) += 1;
-                return false;
-            }
-
-            // TODO move to free template function
-            auto *dense_r = gko::as<dist_vec>(updater.residual_);
-            auto norm1 = vec::create(exec, gko::dim<2>{1, 1});
-            dense_r->compute_norm1(norm1.get());
-            auto norm1_host =
-                vec::create(exec->get_master(), gko::dim<2>{1, 1});
-            norm1_host->copy_from(norm1.get());
-            scalar residual_norm = norm1_host->at(0);
-            // TODO end
-
-            bool result = false;
-
-            // Store initial residual
-            if (*(parameters_.iter) == 0) {
-                //
-                if (eval_norm_factor_) {
-                    norm_factor_ = compute_normfactor_dist(
-                        exec, dense_r, parameters_.gkomatrix, parameters_.x,
-                        parameters_.b);
-                }
-
-                *(parameters_.init_residual_norm) =
-                    residual_norm / norm_factor_;
-            }
-
-            residual_norm /= norm_factor_;
-
-            if (parameters_.export_res) {
-                parameters_.residual_norms->at(*(parameters_.iter)) =
-                    residual_norm;
-            }
-
-            *(parameters_.residual_norm) = residual_norm;
-
-            scalar init_residual = *(parameters_.init_residual_norm);
-
-            // stop if maximum number of iterations was reached
-            if (*(parameters_.iter) == parameters_.openfoam_maxIter) {
-                result = true;
-            }
-            // check if absolute tolerance is hit
-            if (residual_norm < parameters_.openfoam_absolute_tolerance) {
-                result = true;
-            }
-            // check if relative tolerance is hit
-            if (parameters_.openfoam_relative_tolerance > 0 &&
-                residual_norm <
-                    parameters_.openfoam_relative_tolerance * init_residual) {
-                result = true;
-            }
-
-            if (result) {
-                this->set_all_statuses(stoppingId, setFinalized, stop_status);
-                *one_changed = true;
-            }
-
-            *(parameters_.iter) += 1;
-
-            auto end_eval = std::chrono::steady_clock::now();
-            *(parameters_.time) =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    end_eval - start_eval)
-                    .count() /
-                1.0;
-            return result;
-        }
+                        const Criterion::Updater &updater) override;
 
 
         explicit OpenFOAMDistStoppingCriterion(
@@ -396,6 +261,7 @@ public:
     scalar get_res_norm() const { return normalised_res_norm_; }
 
     std::shared_ptr<vec> get_res_norms() const { return normalised_res_norms_; }
+
     label get_is_final() const { return relTol_ == 0.0; }
 
     label get_num_iters() const { return iter_; }

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -200,8 +200,7 @@ public:
           adapt_minIter_(
               controlDict.lookupOrDefault<Switch>("adaptMinIter", true)),
           normalised_res_norms_(gko::share(vec::create(
-              gko::ReferenceExecutor::create(),
-              gko::dim<2>{maxIter_, 1}))),
+              gko::ReferenceExecutor::create(), gko::dim<2>{maxIter_, 1}))),
           init_normalised_res_norm_(0),
           normalised_res_norm_(0),
           iter_(0),

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -201,7 +201,7 @@ public:
               controlDict.lookupOrDefault<Switch>("adaptMinIter", true)),
           normalised_res_norms_(gko::share(vec::create(
               gko::ReferenceExecutor::create(),
-              gko::dim<2>{(gko::dim<2>::dimension_type)maxIter_, 1}))),
+              gko::dim<2>{maxIter_, 1}))),
           init_normalised_res_norm_(0),
           normalised_res_norm_(0),
           iter_(0),

--- a/common/common.C
+++ b/common/common.C
@@ -50,11 +50,11 @@ void export_x(const std::string fn, const gko::matrix::Csr<scalar> *A)
 }
 
 void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
-                const word time)
+                const objectRegistry &db)
 {
-    system("mkdir -p export/" + time);
-    std::string fn_mtx{"export/" + time + "/" + fieldName + ".mtx"};
-    export_x(fn_mtx, x);
+    std::string folder{db.time().timePath()};
+    std::string fn{folder + "/" + fieldName + "_b_.mtx"};
+    export_x(fn, x);
 }
 
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,

--- a/common/common.H
+++ b/common/common.H
@@ -122,7 +122,7 @@ void export_system(const word fieldName, const gko::matrix::Csr<scalar> *A,
                    const gko::matrix::Dense<scalar> *b, const word time);
 
 void export_vec(const word fieldName, const gko::matrix::Dense<scalar> *x,
-                const word time);
+                const objectRegistry &db);
 
 void export_mtx(const word fieldName, std::shared_ptr<const gko::LinOp> A,
                 const word local, const objectRegistry &db,

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -285,7 +285,7 @@ public:
         if (debug && db_.time().writeTime()) {
             LOG_0(verbose_, "Export system")
             dist_A.write();
-	    dist_b.write();
+            dist_b.write();
         }
 
 

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -285,7 +285,7 @@ public:
         if (debug && db_.time().writeTime()) {
             LOG_0(verbose_, "Export system")
             dist_A.write();
-            export_vec(this->fieldName(), dist_b_v->get_local_vector(), db_);
+	    dist_b.write();
         }
 
 

--- a/lduLduBase/lduLduBase.H
+++ b/lduLduBase/lduLduBase.H
@@ -258,7 +258,7 @@ public:
             partition,
             verbose_,
             solver_controls_.lookupOrDefault<Switch>("updateInitGuess", false),
-            false  // whether data for init is on device/
+            false  // whether data for init is on device
         };
         auto dist_x_v = dist_x.get_vector();
         auto dist_b_v = dist_b.get_vector();
@@ -283,21 +283,9 @@ public:
 
         bool debug(solver_controls_.lookupOrDefault<Switch>("debug", false));
         if (debug && db_.time().writeTime()) {
-            word matrix_format(
-                solver_controls_.lookupOrDefault<word>("matrixFormat", "Coo"));
             LOG_0(verbose_, "Export system")
-            export_mtx(
-                this->fieldName(),
-                gko::as<gko::experimental::distributed::Matrix<scalar, label,
-                                                               label>>(dist_A_v)
-                    ->get_local_matrix(),
-                "local", db_, matrix_format);
-            export_mtx(
-                this->fieldName(),
-                gko::as<gko::experimental::distributed::Matrix<scalar, label,
-                                                               label>>(dist_A_v)
-                    ->get_non_local_matrix(),
-                "non_local", db_, matrix_format);
+            dist_A.write();
+            export_vec(this->fieldName(), dist_b_v->get_local_vector(), db_);
         }
 
 

--- a/unitTests/CMakeLists.txt
+++ b/unitTests/CMakeLists.txt
@@ -13,14 +13,25 @@ FetchContent_MakeAvailable(googletest)
 
 add_executable(matrixConversion "test_HostMatrix.C")
 
+find_package(MPI REQUIRED)
+
+target_include_directories(
+    matrixConversion SYSTEM
+  PUBLIC $ENV{FOAM_SRC}/finiteVolume/lnInclude
+         $ENV{FOAM_SRC}/meshTools/lnInclude $ENV{FOAM_SRC}/OpenFOAM/lnInclude
+         $ENV{FOAM_SRC}/OSspecific/POSIX/lnInclude ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_compile_definitions(matrixConversion PUBLIC WM_LABEL_SIZE=32 WM_ARCH_OPTION=64
+                              NoRepository WM_DP)
+
 target_link_libraries(
   matrixConversion
   PUBLIC GTest::gtest_main
-         OGL
          $ENV{FOAM_LIBBIN}/libOpenFOAM.so
          $ENV{FOAM_LIBBIN}/libfiniteVolume.so
          $ENV{FOAM_LIBBIN}/$ENV{FOAM_MPI}/libPstream.so
-         $ENV{FOAM_LIBBIN}/libOSspecific.o
+         OGL
+         # MPI::MPI_CXX
          ${CMAKE_DL_LIBS})
 
 include(GoogleTest)

--- a/unitTests/test_HostMatrix.C
+++ b/unitTests/test_HostMatrix.C
@@ -5,24 +5,26 @@ TEST(HostMatrixConversion, symmetric_update)
 {
     /* test a 5x5 symmetric matrix
      * A =
-     * | 1  1  .  2  .  |
-     * | 1  1  1  .  2  |
-     * | .  1  1  1  .  |
-     * | 2  .  1  1  1  |
-     * | .  2  .  1  1  |
+     * | 1  10  .  20  .  |
+     * | 10  2  11  .  21 |
+     * | .  11   3  12  . |
+     * | 20  .  12  4  13 |
+     * | .  21  .  13   5 |
      */
 
-    std::vector<scalar> d{1., 1., 1., 1., 1.};
-    std::vector<scalar> u{1., 2., 1., 2., 1., 1.};
-    std::vector<label> p{6, 0, 1, 0, 7, 2, 3, 2, 8, 4, 1, 4, 9, 5, 3, 5, 10};
+    std::vector<scalar> d{1., 2., 3., 4., 5.};
+    // for OpenFOAMs addressing see
+    // https://openfoamwiki.net/index.php/OpenFOAM_guide/Matrices_in_OpenFOAM
+    std::vector<scalar> u{10., 11., 20., 12., 21., 13.};
+    std::vector<label> p{6, 0, 2, 0, 7, 1, 4, 1, 8, 3, 2, 3, 9, 5, 4, 5, 10};
 
     label total_nnz{17};
     label upper_nnz{6};
 
     std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
                             0., 0., 0., 0., 0., 0., 0., 0.};
-    std::vector<scalar> exp{1., 1., 2., 1., 1., 1., 2., 1., 1.,
-                            1., 2., 1., 1., 1., 2., 1., 1.};
+    std::vector<scalar> exp{1., 10., 20., 10., 2., 11., 21., 11., 3.,
+                            12., 20., 12., 4., 13., 21., 13., 5.};
 
     Foam::symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
                            u.data(), res.data());

--- a/unitTests/test_HostMatrix.C
+++ b/unitTests/test_HostMatrix.C
@@ -31,73 +31,73 @@ TEST(HostMatrixConversion, symmetric_update)
 
     EXPECT_EQ(res, exp);
 }
-//
-// TEST(HostMatrixConversion, non_symmetric_update)
-// {
-//     /* test a 5x5 symmetric matrix
-//      * A =
-//      * | 1  1  .  2  .  |
-//      * | 2  1  1  .  2  |
-//      * | .  2  1  1  .  |
-//      * | 3  .  2  1  1  |
-//      * | .  3  .  2  1  |
-//      */
-//
-//     std::vector<scalar> d{1., 1., 1., 1., 1.};
-//     std::vector<scalar> u{1., 2., 1., 2., 1., 1.};
-//     std::vector<scalar> l{2., 2., 3., 2., 3., 2.};
-//     std::vector<label> p{12, 0, 1, 6,  13, 2,  3,  7, 14,
-//                          4,  8, 9, 15, 5,  10, 11, 16};
-//
-//     label total_nnz{17};
-//     label upper_nnz{6};
-//
-//     std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
-//                             0., 0., 0., 0., 0., 0., 0., 0.};
-//     std::vector<scalar> exp{1., 1., 2., 2., 1., 1., 2., 2., 1.,
-//                             1., 3., 2., 1., 1., 3., 2., 1.};
-//
-//     Foam::non_symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
-//                                u.data(), l.data(), res.data());
-//
-//     EXPECT_EQ(res, exp);
-// }
-//
-// TEST(HostMatrixConversion, init_local_sparsisty)
-// {
-//     /* test a 5x5 symmetric matrix
-//      * A =
-//      *     0  1  2  3  4
-//      * 0 | x  x  .  x  .  |
-//      * 1 | x  x  x  .  x  |
-//      * 2 | .  x  x  x  .  |
-//      * 3 | x  .  x  x  x  |
-//      * 4 | .  x  .  x  x  |
-//      */
-//
-//     const label nrows = 5;
-//     const label upper_nnz = 6;
-//     const bool is_symmetric = true;
-//
-//     std::vector<label> upper{1, 3, 2, 4, 3, 4};
-//     std::vector<label> lower{0, 0, 1, 1, 2, 3};
-//
-//     std::vector<label> rows{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-//     std::vector<label> cols{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-//     std::vector<label> permute{0, 0, 0, 0, 0, 0, 0, 0, 0,
-//                                0, 0, 0, 0, 0, 0, 0, 0};
-//
-//     std::vector<label> rows_exp{0, 0, 0, 1, 1, 1, 1, 2, 2,
-//                                 2, 3, 3, 3, 3, 4, 4, 4};
-//     std::vector<label> cols_exp{0, 1, 3, 0, 1, 2, 4, 1, 2,
-//                                 3, 0, 2, 3, 4, 1, 3, 4};
-//     std::vector<label> permute_exp{6, 0, 1, 0, 7, 2, 3, 2, 8,
-//                                    4, 1, 4, 9, 5, 3, 5, 10};
-//     Foam::init_local_sparsity(nrows, upper_nnz, is_symmetric, upper.data(),
-//                               lower.data(), rows.data(), cols.data(),
-//                               permute.data());
-//
-//     EXPECT_EQ(rows, rows_exp);
-//     EXPECT_EQ(cols, cols_exp);
-//     EXPECT_EQ(permute, permute_exp);
-// }
+
+TEST(HostMatrixConversion, non_symmetric_update)
+{
+    /* test a 5x5 symmetric matrix
+     * A =
+     * | 1  1  .  2  .  |
+     * | 2  1  1  .  2  |
+     * | .  2  1  1  .  |
+     * | 3  .  2  1  1  |
+     * | .  3  .  2  1  |
+     */
+
+    std::vector<scalar> d{1., 1., 1., 1., 1.};
+    std::vector<scalar> u{1., 2., 1., 2., 1., 1.};
+    std::vector<scalar> l{2., 2., 3., 2., 3., 2.};
+    std::vector<label> p{12, 0, 1, 6,  13, 2,  3,  7, 14,
+                         4,  8, 9, 15, 5,  10, 11, 16};
+
+    label total_nnz{17};
+    label upper_nnz{6};
+
+    std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+                            0., 0., 0., 0., 0., 0., 0., 0.};
+    std::vector<scalar> exp{1., 1., 2., 2., 1., 1., 2., 2., 1.,
+                            1., 3., 2., 1., 1., 3., 2., 1.};
+
+    Foam::non_symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
+                               u.data(), l.data(), res.data());
+
+    EXPECT_EQ(res, exp);
+}
+
+TEST(HostMatrixConversion, init_local_sparsisty)
+{
+    /* test a 5x5 symmetric matrix
+     * A =
+     *     0  1  2  3  4
+     * 0 | x  x  .  x  .  |
+     * 1 | x  x  x  .  x  |
+     * 2 | .  x  x  x  .  |
+     * 3 | x  .  x  x  x  |
+     * 4 | .  x  .  x  x  |
+     */
+
+    const label nrows = 5;
+    const label upper_nnz = 6;
+    const bool is_symmetric = true;
+
+    std::vector<label> upper{1, 3, 2, 4, 3, 4};
+    std::vector<label> lower{0, 0, 1, 1, 2, 3};
+
+    std::vector<label> rows{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<label> cols{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    std::vector<label> permute{0, 0, 0, 0, 0, 0, 0, 0, 0,
+                               0, 0, 0, 0, 0, 0, 0, 0};
+
+    std::vector<label> rows_exp{0, 0, 0, 1, 1, 1, 1, 2, 2,
+                                2, 3, 3, 3, 3, 4, 4, 4};
+    std::vector<label> cols_exp{0, 1, 3, 0, 1, 2, 4, 1, 2,
+                                3, 0, 2, 3, 4, 1, 3, 4};
+    std::vector<label> permute_exp{6, 0, 1, 0, 7, 2, 3, 2, 8,
+                                   4, 1, 4, 9, 5, 3, 5, 10};
+    Foam::init_local_sparsity(nrows, upper_nnz, is_symmetric, upper.data(),
+                              lower.data(), rows.data(), cols.data(),
+                              permute.data());
+
+    EXPECT_EQ(rows, rows_exp);
+    EXPECT_EQ(cols, cols_exp);
+    EXPECT_EQ(permute, permute_exp);
+}

--- a/unitTests/test_HostMatrix.C
+++ b/unitTests/test_HostMatrix.C
@@ -29,73 +29,73 @@ TEST(HostMatrixConversion, symmetric_update)
 
     EXPECT_EQ(res, exp);
 }
-
-TEST(HostMatrixConversion, non_symmetric_update)
-{
-    /* test a 5x5 symmetric matrix
-     * A =
-     * | 1  1  .  2  .  |
-     * | 2  1  1  .  2  |
-     * | .  2  1  1  .  |
-     * | 3  .  2  1  1  |
-     * | .  3  .  2  1  |
-     */
-
-    std::vector<scalar> d{1., 1., 1., 1., 1.};
-    std::vector<scalar> u{1., 2., 1., 2., 1., 1.};
-    std::vector<scalar> l{2., 2., 3., 2., 3., 2.};
-    std::vector<label> p{12, 0, 1, 6,  13, 2,  3,  7, 14,
-                         4,  8, 9, 15, 5,  10, 11, 16};
-
-    label total_nnz{17};
-    label upper_nnz{6};
-
-    std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
-                            0., 0., 0., 0., 0., 0., 0., 0.};
-    std::vector<scalar> exp{1., 1., 2., 2., 1., 1., 2., 2., 1.,
-                            1., 3., 2., 1., 1., 3., 2., 1.};
-
-    Foam::non_symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
-                               u.data(), l.data(), res.data());
-
-    EXPECT_EQ(res, exp);
-}
-
-TEST(HostMatrixConversion, init_local_sparsisty)
-{
-    /* test a 5x5 symmetric matrix
-     * A =
-     *     0  1  2  3  4
-     * 0 | x  x  .  x  .  |
-     * 1 | x  x  x  .  x  |
-     * 2 | .  x  x  x  .  |
-     * 3 | x  .  x  x  x  |
-     * 4 | .  x  .  x  x  |
-     */
-
-    const label nrows = 5;
-    const label upper_nnz = 6;
-    const bool is_symmetric = true;
-
-    std::vector<label> upper{1, 3, 2, 4, 3, 4};
-    std::vector<label> lower{0, 0, 1, 1, 2, 3};
-
-    std::vector<label> rows{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    std::vector<label> cols{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    std::vector<label> permute{0, 0, 0, 0, 0, 0, 0, 0, 0,
-                               0, 0, 0, 0, 0, 0, 0, 0};
-
-    std::vector<label> rows_exp{0, 0, 0, 1, 1, 1, 1, 2, 2,
-                                2, 3, 3, 3, 3, 4, 4, 4};
-    std::vector<label> cols_exp{0, 1, 3, 0, 1, 2, 4, 1, 2,
-                                3, 0, 2, 3, 4, 1, 3, 4};
-    std::vector<label> permute_exp{6, 0, 1, 0, 7, 2, 3, 2, 8,
-                                   4, 1, 4, 9, 5, 3, 5, 10};
-    Foam::init_local_sparsity(nrows, upper_nnz, is_symmetric, upper.data(),
-                              lower.data(), rows.data(), cols.data(),
-                              permute.data());
-
-    EXPECT_EQ(rows, rows_exp);
-    EXPECT_EQ(cols, cols_exp);
-    EXPECT_EQ(permute, permute_exp);
-}
+//
+// TEST(HostMatrixConversion, non_symmetric_update)
+// {
+//     /* test a 5x5 symmetric matrix
+//      * A =
+//      * | 1  1  .  2  .  |
+//      * | 2  1  1  .  2  |
+//      * | .  2  1  1  .  |
+//      * | 3  .  2  1  1  |
+//      * | .  3  .  2  1  |
+//      */
+//
+//     std::vector<scalar> d{1., 1., 1., 1., 1.};
+//     std::vector<scalar> u{1., 2., 1., 2., 1., 1.};
+//     std::vector<scalar> l{2., 2., 3., 2., 3., 2.};
+//     std::vector<label> p{12, 0, 1, 6,  13, 2,  3,  7, 14,
+//                          4,  8, 9, 15, 5,  10, 11, 16};
+//
+//     label total_nnz{17};
+//     label upper_nnz{6};
+//
+//     std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
+//                             0., 0., 0., 0., 0., 0., 0., 0.};
+//     std::vector<scalar> exp{1., 1., 2., 2., 1., 1., 2., 2., 1.,
+//                             1., 3., 2., 1., 1., 3., 2., 1.};
+//
+//     Foam::non_symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
+//                                u.data(), l.data(), res.data());
+//
+//     EXPECT_EQ(res, exp);
+// }
+//
+// TEST(HostMatrixConversion, init_local_sparsisty)
+// {
+//     /* test a 5x5 symmetric matrix
+//      * A =
+//      *     0  1  2  3  4
+//      * 0 | x  x  .  x  .  |
+//      * 1 | x  x  x  .  x  |
+//      * 2 | .  x  x  x  .  |
+//      * 3 | x  .  x  x  x  |
+//      * 4 | .  x  .  x  x  |
+//      */
+//
+//     const label nrows = 5;
+//     const label upper_nnz = 6;
+//     const bool is_symmetric = true;
+//
+//     std::vector<label> upper{1, 3, 2, 4, 3, 4};
+//     std::vector<label> lower{0, 0, 1, 1, 2, 3};
+//
+//     std::vector<label> rows{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+//     std::vector<label> cols{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+//     std::vector<label> permute{0, 0, 0, 0, 0, 0, 0, 0, 0,
+//                                0, 0, 0, 0, 0, 0, 0, 0};
+//
+//     std::vector<label> rows_exp{0, 0, 0, 1, 1, 1, 1, 2, 2,
+//                                 2, 3, 3, 3, 3, 4, 4, 4};
+//     std::vector<label> cols_exp{0, 1, 3, 0, 1, 2, 4, 1, 2,
+//                                 3, 0, 2, 3, 4, 1, 3, 4};
+//     std::vector<label> permute_exp{6, 0, 1, 0, 7, 2, 3, 2, 8,
+//                                    4, 1, 4, 9, 5, 3, 5, 10};
+//     Foam::init_local_sparsity(nrows, upper_nnz, is_symmetric, upper.data(),
+//                               lower.data(), rows.data(), cols.data(),
+//                               permute.data());
+//
+//     EXPECT_EQ(rows, rows_exp);
+//     EXPECT_EQ(cols, cols_exp);
+//     EXPECT_EQ(permute, permute_exp);
+// }

--- a/unitTests/test_HostMatrix.C
+++ b/unitTests/test_HostMatrix.C
@@ -23,8 +23,8 @@ TEST(HostMatrixConversion, symmetric_update)
 
     std::vector<scalar> res{0., 0., 0., 0., 0., 0., 0., 0., 0.,
                             0., 0., 0., 0., 0., 0., 0., 0.};
-    std::vector<scalar> exp{1., 10., 20., 10., 2., 11., 21., 11., 3.,
-                            12., 20., 12., 4., 13., 21., 13., 5.};
+    std::vector<scalar> exp{1.,  10., 20., 10., 2.,  11., 21., 11., 3.,
+                            12., 20., 12., 4.,  13., 21., 13., 5.};
 
     Foam::symmetric_update(total_nnz, upper_nnz, p.data(), 1.0, d.data(),
                            u.data(), res.data());


### PR DESCRIPTION
This PR implements reorder on device, see #100. The behavior can be controlled via the `reorderOnHost` dictionary entry. If set to false (default) the ldu matrix coefficients are copied to a consecutive array on the device with the following order c = [u,l,d]. After copying `row_gather` reorders c using the permutation map.

Initial benchmark data on a single node can be found [here](https://github.com/exasim-project/benchmark_data/pull/4) 
