### PR TITLE
Fix hanging solves for diverging cases

### DIFF
--- a/StoppingCriterion/StoppingCriterion.C
+++ b/StoppingCriterion/StoppingCriterion.C
@@ -38,7 +38,7 @@ void StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_Axref_dist(
     xAvg->move_to(xAvg_host);
     auto xAvg_vec = gko::share(
         dist_vec::create(device_exec, x->get_communicator(),
-                         gko::dim<2>{global_size}, gko::dim<2>{local_size}));
+                         gko::dim<2>{global_size,1}, gko::dim<2>{local_size,1}));
     xAvg_vec->fill(xAvg_host->at(0));
 
     gkomatrix->apply(xAvg_vec.get(), res.get());

--- a/StoppingCriterion/StoppingCriterion.C
+++ b/StoppingCriterion/StoppingCriterion.C
@@ -21,7 +21,152 @@ License
 
 // * * * * * * * * * * * * * * Static Data Members * * * * * * * * * * * * * //
 
-namespace Foam {}  // namespace Foam
+namespace Foam {
+
+void StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_Axref_dist(
+    size_t global_size, size_t local_size,
+    std::shared_ptr<const gko::Executor> device_exec,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x, std::shared_ptr<dist_vec> res) const
+{
+    auto xAvg =
+        gko::initialize<gko::matrix::Dense<scalar>>(1, {0}, device_exec);
+    x->compute_mean(xAvg.get());
+
+    auto xAvg_host = gko::initialize<gko::matrix::Dense<scalar>>(
+        1, {0}, device_exec->get_master());
+    xAvg->move_to(xAvg_host);
+    auto xAvg_vec = gko::share(
+        dist_vec::create(device_exec, x->get_communicator(),
+                         gko::dim<2>{global_size}, gko::dim<2>{local_size}));
+    xAvg_vec->fill(xAvg_host->at(0));
+
+    gkomatrix->apply(xAvg_vec.get(), res.get());
+}
+
+scalar
+StoppingCriterion::OpenFOAMDistStoppingCriterion::compute_normfactor_dist(
+    std::shared_ptr<const gko::Executor> device_exec, const dist_vec *r,
+    std::shared_ptr<const gko::LinOp> gkomatrix,
+    std::shared_ptr<const dist_vec> x, std::shared_ptr<const dist_vec> b) const
+{
+    // TODO store colA vector
+    auto comm = x->get_communicator();
+
+    gko::dim<2> local_size = x->get_local_vector()->get_size();
+    gko::dim<2> global_size = x->get_size();
+
+    auto Axref = gko::share(
+        dist_vec::create(device_exec, comm, global_size, local_size));
+
+    compute_Axref_dist(global_size[0], local_size[0], device_exec, gkomatrix, x,
+                       Axref);
+
+    auto unity =
+        gko::initialize<gko::matrix::Dense<scalar>>(1, {1.0}, device_exec);
+
+    auto b_sub_xstar = b->clone();
+    b_sub_xstar->sub_scaled(unity.get(), Axref.get());
+
+    auto norm_part2 = b_sub_xstar->compute_absolute();
+
+    b_sub_xstar->sub_scaled(unity.get(), r);
+    b_sub_xstar->compute_absolute_inplace();
+
+    b_sub_xstar->add_scaled(unity.get(), norm_part2.get());
+    auto res = vec::create(device_exec, gko::dim<2>{1});
+    b_sub_xstar->compute_norm1(res.get());
+
+    auto res_host = vec::create(device_exec->get_master(), gko::dim<2>{1});
+    res_host->copy_from(res.get());
+
+    return res_host->get_values()[0] + SMALL;
+}
+
+bool StoppingCriterion::OpenFOAMDistStoppingCriterion::check_impl(
+    gko::uint8 stoppingId, bool setFinalized,
+    gko::array<gko::stopping_status> *stop_status, bool *one_changed,
+    const Criterion::Updater &updater)
+{
+    // Dont check residual norm before minIter is reached
+    if (*(parameters_.iter) > 0 &&
+        *(parameters_.iter) < parameters_.openfoam_minIter) {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    // Only check residual for every frequency iteration
+    if (*(parameters_.iter) % parameters_.frequency != 0) {
+        *(parameters_.iter) += 1;
+        return false;
+    }
+
+    auto start_eval = std::chrono::steady_clock::now();
+    const auto exec = this->get_executor();
+
+    auto *dense_r = gko::as<dist_vec>(updater.residual_);
+    auto norm1 = vec::create(exec, gko::dim<2>{1});
+    dense_r->compute_norm1(norm1.get());
+    auto norm1_host = vec::create(exec->get_master(), gko::dim<2>{1});
+    norm1_host->copy_from(norm1.get());
+    scalar residual_norm = norm1_host->at(0);
+
+    bool result = false;
+
+    // Store initial residual
+    if (*(parameters_.iter) == 0) {
+        //
+        if (eval_norm_factor_) {
+            norm_factor_ =
+                compute_normfactor_dist(exec, dense_r, parameters_.gkomatrix,
+                                        parameters_.x, parameters_.b);
+        }
+
+        *(parameters_.init_residual_norm) = residual_norm / norm_factor_;
+    }
+
+    residual_norm /= norm_factor_;
+
+    if (parameters_.export_res) {
+        parameters_.residual_norms->at(*(parameters_.iter)) = residual_norm;
+    }
+
+    *(parameters_.residual_norm) = residual_norm;
+
+    scalar init_residual = *(parameters_.init_residual_norm);
+
+    // stop if maximum number of iterations was reached
+    if (*(parameters_.iter) >= parameters_.openfoam_maxIter) {
+        result = true;
+    }
+    // check if absolute tolerance is hit
+    if (residual_norm < parameters_.openfoam_absolute_tolerance) {
+        result = true;
+    }
+    // check if relative tolerance is hit
+    if (parameters_.openfoam_relative_tolerance > 0 &&
+        residual_norm <
+            parameters_.openfoam_relative_tolerance * init_residual) {
+        result = true;
+    }
+
+    if (result) {
+        this->set_all_statuses(stoppingId, setFinalized, stop_status);
+        *one_changed = true;
+    }
+
+    *(parameters_.iter) += 1;
+
+    auto end_eval = std::chrono::steady_clock::now();
+    *(parameters_.time) = std::chrono::duration_cast<std::chrono::microseconds>(
+                              end_eval - start_eval)
+                              .count() /
+                          1.0;
+    return result;
+}
+
+
+}  // namespace Foam
 
 
 // * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -100,167 +100,32 @@ class StoppingCriterion {
 
         GKO_ENABLE_BUILD_METHOD(Factory);
 
-        // protected:
-        /* Compute the SPMV of A with x_ref
-         *
-         *
+        /* Compute the SpMV of A with x_ref, where x_ref is a vector containing
+         * the average of x in every row. This is needed to initialise the
+         * normfactor in the first iteration.
          *  */
         void compute_Axref_dist(
             size_t global_size, size_t local_size,
             std::shared_ptr<const gko::Executor> device_exec,
             std::shared_ptr<const gko::LinOp> gkomatrix,
-            std::shared_ptr<dist_vec> x, std::shared_ptr<dist_vec> res) const
-        {
-            auto xAvg = gko::initialize<gko::matrix::Dense<scalar>>(
-                1, {0}, device_exec);
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<dist_vec> res) const;
 
-            x->compute_mean(xAvg.get());
-
-#ifdef GINKGO_WITH_OGL_EXTENSIONS
-            gkomatrix->compute_column_vector_sum(res.get());
-            res->scale(xAvg.get());
-#else
-            // if column vector sum is not available use dot product
-            auto xAvg_vec = gko::share(dist_vec::create(
-                device_exec, x->get_communicator(), gko::dim<2>{global_size, 1},
-                gko::dim<2>{local_size, 1}));
-            xAvg_vec->fill(1.0);
-            xAvg_vec->scale(xAvg.get());
-
-            gkomatrix->apply(xAvg_vec.get(), res.get());
-#endif
-        }
-
-
+        /* Compute the normfactor ie || Ax - x* || + || b - x* ||
+         * or rewritten as || r - ( b - x* ) || + || (b - x*) ||
+         *  */
         scalar compute_normfactor_dist(
             std::shared_ptr<const gko::Executor> device_exec, const dist_vec *r,
             std::shared_ptr<const gko::LinOp> gkomatrix,
-            std::shared_ptr<dist_vec> x,
-            std::shared_ptr<const dist_vec> b) const
-        {
-            // SIMPLE_TIME(verbose_, compute_col_sum_A, [=]() {
-            // computes        || Ax - x* ||        + || b - x* ||
-            // or rewritten as || r - ( b - x* ) || + || (b - x*) ||
+            std::shared_ptr<const dist_vec> x,
+            std::shared_ptr<const dist_vec> b) const;
 
-            // TODO store colA vector
-            auto comm = x->get_communicator();
-
-            gko::dim<2> local_size = x->get_local_vector()->get_size();
-            gko::dim<2> global_size = x->get_size();
-
-            auto Axref = gko::share(
-                dist_vec::create(device_exec, comm, global_size, local_size));
-
-            compute_Axref_dist(global_size[0], local_size[0], device_exec,
-                               gkomatrix, x, Axref);
-
-            auto unity = gko::initialize<gko::matrix::Dense<scalar>>(
-                1, {1.0}, device_exec);
-
-            auto b_sub_xstar = b->clone();
-            b_sub_xstar->sub_scaled(unity.get(), Axref.get());
-
-            auto norm_part2 = b_sub_xstar->compute_absolute();
-
-            b_sub_xstar->sub_scaled(unity.get(), r);
-            b_sub_xstar->compute_absolute_inplace();
-
-            b_sub_xstar->add_scaled(unity.get(), norm_part2.get());
-            auto res = vec::create(device_exec, gko::dim<2>{1, 1});
-            b_sub_xstar->compute_norm1(res.get());
-
-            auto res_host =
-                vec::create(device_exec->get_master(), gko::dim<2>{1, 1});
-            res_host->copy_from(res.get());
-
-            return res_host->get_values()[0] + SMALL;
-        }
-
+        /* Implementation of the residual norm check
+         *  */
         bool check_impl(gko::uint8 stoppingId, bool setFinalized,
                         gko::array<gko::stopping_status> *stop_status,
                         bool *one_changed,
-                        const Criterion::Updater &updater) override
-        {
-            auto start_eval = std::chrono::steady_clock::now();
-            if (*(parameters_.iter) > 0 &&
-                *(parameters_.iter) < parameters_.openfoam_minIter) {
-                *(parameters_.iter) += 1;
-                return false;
-            }
-
-            const auto exec = this->get_executor();
-
-            if (*(parameters_.iter) % parameters_.frequency != 0) {
-                *(parameters_.iter) += 1;
-                return false;
-            }
-
-            // TODO move to free template function
-            auto *dense_r = gko::as<dist_vec>(updater.residual_);
-            auto norm1 = vec::create(exec, gko::dim<2>{1, 1});
-            dense_r->compute_norm1(norm1.get());
-            auto norm1_host =
-                vec::create(exec->get_master(), gko::dim<2>{1, 1});
-            norm1_host->copy_from(norm1.get());
-            scalar residual_norm = norm1_host->at(0);
-            // TODO end
-
-            bool result = false;
-
-            // Store initial residual
-            if (*(parameters_.iter) == 0) {
-                //
-                if (eval_norm_factor_) {
-                    norm_factor_ = compute_normfactor_dist(
-                        exec, dense_r, parameters_.gkomatrix, parameters_.x,
-                        parameters_.b);
-                }
-
-                *(parameters_.init_residual_norm) =
-                    residual_norm / norm_factor_;
-            }
-
-            residual_norm /= norm_factor_;
-
-            if (parameters_.export_res) {
-                parameters_.residual_norms->at(*(parameters_.iter)) =
-                    residual_norm;
-            }
-
-            *(parameters_.residual_norm) = residual_norm;
-
-            scalar init_residual = *(parameters_.init_residual_norm);
-
-            // stop if maximum number of iterations was reached
-            if (*(parameters_.iter) == parameters_.openfoam_maxIter) {
-                result = true;
-            }
-            // check if absolute tolerance is hit
-            if (residual_norm < parameters_.openfoam_absolute_tolerance) {
-                result = true;
-            }
-            // check if relative tolerance is hit
-            if (parameters_.openfoam_relative_tolerance > 0 &&
-                residual_norm <
-                    parameters_.openfoam_relative_tolerance * init_residual) {
-                result = true;
-            }
-
-            if (result) {
-                this->set_all_statuses(stoppingId, setFinalized, stop_status);
-                *one_changed = true;
-            }
-
-            *(parameters_.iter) += 1;
-
-            auto end_eval = std::chrono::steady_clock::now();
-            *(parameters_.time) =
-                std::chrono::duration_cast<std::chrono::microseconds>(
-                    end_eval - start_eval)
-                    .count() /
-                1.0;
-            return result;
-        }
+                        const Criterion::Updater &updater) override;
 
 
         explicit OpenFOAMDistStoppingCriterion(
@@ -396,6 +261,7 @@ public:
     scalar get_res_norm() const { return normalised_res_norm_; }
 
     std::shared_ptr<vec> get_res_norms() const { return normalised_res_norms_; }
+
     label get_is_final() const { return relTol_ == 0.0; }
 
     label get_num_iters() const { return iter_; }

--- a/StoppingCriterion/StoppingCriterion.H
+++ b/StoppingCriterion/StoppingCriterion.H
@@ -201,7 +201,7 @@ public:
               controlDict.lookupOrDefault<Switch>("adaptMinIter", true)),
           normalised_res_norms_(gko::share(vec::create(
               gko::ReferenceExecutor::create(),
-              gko::dim<2>{(gko::dim<2>::dimension_type)maxIter_, 1}))),
+              gko::dim<2>{maxIter_, 1}))),
           init_normalised_res_norm_(0),
           normalised_res_norm_(0),
           iter_(0),


### PR DESCRIPTION
In certain situations, the OGL solver can end up in a hanging state. This happens if:
1. The solver doesn't converge and
2. the residual norm check frequency does not add up to the maximum iterations, ie min_iter + n * frequency != max_iter

This PR fixes the infinite loop and moves  implementation to the .C file.