### PR TITLE
Fix cmake build process.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-# 0.5.1 (2024/01/11)
-- Fix issue with failing cmake build
+# 0.5.1 (2024/01/18)
+- Fix issue with failing cmake build 
 # 0.5.0 (2024/01/11)
 ## Features
 - Add on device permutation functionality [PR #101](https://github.com/hpsim/OGL/pull/101) 


### PR DESCRIPTION
On some machines the cmake build does not work since it can not find the `GinkgoConfig.cmake` file. This has been fixed with 1607b46. This PR is just for updating the Changelog and compile a new release.