### PR TITLE
Add device repartitioning functionality

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,6 @@ jobs:
         key: ws-${{inputs.version}}-${{ github.sha }}
         path: /home/runner/work/_temp/_github_home/integration
 
-
     - name: Update OBR
       working-directory: /github/home/
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.2 (unreleased)
+# 0.5.2 (2024/02/11)
 - Fix issue with cyclic boundary conditions [PR #108](https://github.com/hpsim/OGL/pull/108)
 # 0.5.1 (2024/01/18)
 - Fix issue with failing cmake build 


### PR DESCRIPTION
For a good overall performance, typically a decomposition into 2*n_GPUs up to 4*n_GPUs subdomains performs best.  This PR enables efficient on device repartitioning, such that decompositions up to nCPUs subdomains work without affecting performance negatively.