### PR TITLE
Added exception throw on unsupported Exec names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 builds
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.5.4 (2024/04/10)
+- Notify user of a unsupported executor argument [PR #] 
 # 0.5.3 (2024/03/08)
 - Fix issue when building against DP labels [PR #111](https://github.com/hpsim/OGL/pull/111)
 # 0.5.2 (2024/03/08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.5.4 (2024/04/10)
+# 0.5.4 (unreleased)
 - Notify user of a unsupported executor argument [PR #] 
 # 0.5.3 (2024/03/08)
 - Fix issue when building against DP labels [PR #111](https://github.com/hpsim/OGL/pull/111)

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -115,7 +115,7 @@ struct ExecutorInitFunctor {
         }
 
         FatalErrorInFunction
-            << "OGL does not support the executor: " << name
+            << "OGL does not support the executor: " << executor_name_
             << "\nValid Choices: cuda, hip, dpcpp, omp, reference"
             << abort(FatalError);
         return {};

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -114,7 +114,10 @@ struct ExecutorInitFunctor {
             return host_exec;
         }
 
-        // NOTE Return empty pointer to avoid compiler warnings
+        FatalErrorInFunction
+            << "OGL does not support the executor: " << name
+            << "\nValid Choices: cuda, hip, dpcpp, omp, reference"
+            << abort(FatalError);
         return {};
     }
 };

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -116,7 +116,7 @@ struct ExecutorInitFunctor {
 
         FatalErrorInFunction
             << "OGL does not support the executor: " << executor_name_
-            << "\nValid Choices: cuda, hip, dpcpp, omp, reference"
+            << "\nValid choices are: cuda, hip, dpcpp, omp, or reference"
             << abort(FatalError);
         return {};
     }


### PR DESCRIPTION
Before, it was possible to run OGL with a typo in the executor name argument, which resulted in passing an empty exec pointer without any error description. Now the ExecutorHandler.H throws an invalid argument error just like e.g. the Preconditioner.H handler