### PR TITLE
Rename dpcpp to sycl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 -->
 
 # 0.5.4 (unreleased)
+- Add a warning message to users who use dpcpp as the executor name [PR #129](https://github.com/hpsim/OGL/pull/129)
 - Add support for SP scalars and determine label and scalar size from env variable [PR #120](https://github.com/hpsim/OGL/pull/120) 
 - Notify user of a unsupported executor argument [PR #118](https://github.com/hpsim/OGL/pull/118) 
 - Notify user of a unsupported executor argument [PR #]

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -65,8 +65,8 @@ struct ExecutorInitFunctor {
             };
 
             if (executor_name_ == "dpcpp"){
-                Info<< "Warning: the executor name dpcpp is deprecated. 
-                        Use sycl as the executor name for the same executor instead." << endl;
+                Info<< "Warning: the executor name dpcpp is deprecated\n."
+                    << "Use sycl as the executor name for the same executor instead." << endl;
             }
 
             auto devices = gko::DpcppExecutor::get_num_devices("gpu");

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -64,9 +64,11 @@ struct ExecutorInitFunctor {
                     << abort(FatalError);
             };
 
-            if (executor_name_ == "dpcpp"){
-                Info<< "Warning: the executor name dpcpp is deprecated\n."
-                    << "Use sycl as the executor name for the same executor instead." << endl;
+            if (executor_name_ == "dpcpp") {
+                Info << "Warning: the executor name dpcpp is deprecated\n."
+                     << "Use sycl as the executor name for the same executor "
+                        "instead."
+                     << endl;
             }
 
             auto devices = gko::DpcppExecutor::get_num_devices("gpu");

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -65,7 +65,7 @@ struct ExecutorInitFunctor {
             };
 
             if (executor_name_ == "dpcpp") {
-                Info << "Warning: the executor name dpcpp is deprecated\n."
+                Info << "Warning: the executor name dpcpp is deprecated.\n"
                      << "Use sycl as the executor name for the same executor "
                         "instead."
                      << endl;

--- a/DevicePersistent/ExecutorHandler/ExecutorHandler.H
+++ b/DevicePersistent/ExecutorHandler/ExecutorHandler.H
@@ -56,13 +56,19 @@ struct ExecutorInitFunctor {
             return gko::share(gko::CudaExecutor::create(
                 device_id_ % gko::CudaExecutor::get_num_devices(), host_exec));
         }
-        if (executor_name_ == "dpcpp") {
+        if (executor_name_ == "sycl" || "dpcpp") {
             if (version.dpcpp_version.tag == not_compiled_tag) {
                 FatalErrorInFunction
                     << "SYCL Backend was not compiled. Recompile OGL/Ginkgo "
                        "with SYCL backend enabled."
                     << abort(FatalError);
             };
+
+            if (executor_name_ == "dpcpp"){
+                Info<< "Warning: the executor name dpcpp is deprecated. 
+                        Use sycl as the executor name for the same executor instead." << endl;
+            }
+
             auto devices = gko::DpcppExecutor::get_num_devices("gpu");
             if (devices == 0) {
                 return gko::share(gko::DpcppExecutor::create(0, host_exec));
@@ -97,7 +103,7 @@ struct ExecutorInitFunctor {
 
         FatalErrorInFunction
             << "OGL does not support the executor: " << executor_name_
-            << "\nValid choices are: cuda, hip, dpcpp, omp, or reference"
+            << "\nValid choices are: cuda, hip, sycl, omp, or reference"
             << abort(FatalError);
         return {};
     }


### PR DESCRIPTION
Output a warning message when dpcpp is used as an executor name by a user.