### PR TITLE
implement additional unit tests for communication pattern

### DIFF
--- a/cmake/OpenFOAM.cmake
+++ b/cmake/OpenFOAM.cmake
@@ -25,6 +25,10 @@ if(APPLE)
     OpenFOAM::Pstream
     PROPERTIES IMPORTED_LOCATION
                $ENV{FOAM_LIBBIN}/$ENV{FOAM_MPI}/libPstream.dylib)
+  set_target_properties(
+
+    OpenFOAM::meshtools PROPERTIES IMPORTED_LOCATION
+                                   $ENV{FOAM_LIBBIN}/libmeshTools.dylib)
 else()
   set_target_properties(
     OpenFOAM::core PROPERTIES IMPORTED_LOCATION

--- a/include/OGL/CommunicationPattern.H
+++ b/include/OGL/CommunicationPattern.H
@@ -19,8 +19,8 @@ struct AllToAllPattern {
     std::vector<label> recv_offsets;
 };
 
-/* @brief  This function computes the send and recv counts vectors and the send
- * and recv offsets vectors for scattering from an owner to non  owner ranks
+/* @brief  This function computes the send and recv counts vectors and the send and recv offsets vectors for
+ * scattering from an owner to all ranks, including owner itself
  *
  * @param exec_handler The executor handler
  * @param ranks_per_owner Ratio of the total number of ranks to owner ranks

--- a/src/CommunicationPattern.C
+++ b/src/CommunicationPattern.C
@@ -39,7 +39,7 @@ AllToAllPattern compute_scatter_from_owner_counts(const ExecutorHandler &exec_ha
         send_counts[owner_rank] = size;
         recv_counts[owner_rank] = size;
         // the start of the next rank data
-	label tot_send_elements{size};
+        label tot_send_elements{size};
 
         for (int i = 1; i < ranks_per_owner; i++) {
             // receive the recv counts
@@ -48,7 +48,7 @@ AllToAllPattern compute_scatter_from_owner_counts(const ExecutorHandler &exec_ha
             send_offsets[rank + i] = tot_send_elements;
             tot_send_elements += comm_elements_buffer;
         }
-	send_offsets.back() = tot_send_elements;
+        send_offsets.back() = tot_send_elements;
     } else {
         // send how many elements to communicate
         comm.send(exec, &size, 1, owner_rank, owner_rank);
@@ -60,7 +60,7 @@ AllToAllPattern compute_scatter_from_owner_counts(const ExecutorHandler &exec_ha
     recv_offsets.back() = size;
 
     return AllToAllPattern{
-        send_counts,
+            send_counts,
             send_offsets,
             recv_counts,
             recv_offsets

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -78,33 +78,75 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     std::vector<int> send_counts(comm_size);
     
     if (comm_rank == 0)
-        for (int i = 1; i < comm_size; i++)
+        for (int i = 0; i < comm_size; i++)
             send_counts[i] = num_elements*i;
-      
+
     std::vector<int> recv_counts(comm_size);
 
-    if (comm_rank != 0)
-        recv_counts[0] = num_elements*comm_rank;
+    recv_counts[0] = num_elements*comm_rank;
 
-    std::vector<int> send_offsets(comm_size);
+    std::vector<int> send_offsets(comm_size+1);
     if (comm_rank == 0)
-        for (int i = 0; i < comm_size-1; i++)
+        for (int i = 0; i < comm_size; i++)
             send_offsets[i+1] = send_offsets[i] + num_elements*i;
     
-    std::vector<int> recv_offsets(comm_size);
+    std::vector<int> recv_offsets(comm_size+1);
+    recv_offsets.back() = num_elements * comm_rank;
 
     // Act
     auto comm_counts =
         compute_scatter_from_owner_counts(*exec.get(), comm_size, label(num_elements * comm_rank)); 
 
     // Assert
-    // test send counts and revc counts
     EXPECT_EQ(comm_counts.send_counts, send_counts);
     EXPECT_EQ(comm_counts.recv_counts, recv_counts);
     EXPECT_EQ(comm_counts.send_offsets, send_offsets);
     EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
+
+// TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_two_owners)
+// {
+//     // Arrange
+//     auto comm = exec->get_gko_mpi_host_comm();
+//     auto num_elements = 10;
+//     auto comm_size = comm->size();
+//     auto comm_rank = comm->rank();
+
+//     // Scatter different number of elements from owner to each non-owner process
+//     std::vector<int> send_counts(comm_size);
+    
+//     if (comm_rank == 0)
+//         for (int i = 1; i < comm_size/2; i++)
+//             send_counts[i] = num_elements*i;
+    
+//     if (comm_rank == comm_size/2)
+//         for (int i = comm_size/2 + 1; i < comm_size; i++)
+//             send_counts[i] = num_elements*i;
+      
+//     // std::vector<int> recv_counts(comm_size);
+
+//     // if (comm_rank != 0)
+//     //     recv_counts[0] = num_elements*comm_rank;
+
+//     // std::vector<int> send_offsets(comm_size);
+//     // if (comm_rank == 0)
+//     //     for (int i = 0; i < comm_size-1; i++)
+//     //         send_offsets[i+1] = send_offsets[i] + num_elements*i;
+    
+//     // std::vector<int> recv_offsets(comm_size);
+
+//     // Act
+//     auto comm_counts =
+//         compute_scatter_from_owner_counts(*exec.get(), comm_size/2, label(num_elements * comm_rank)); 
+
+//     // Assert
+//     // test send counts and revc counts
+//     EXPECT_EQ(comm_counts.send_counts, send_counts);
+//     // EXPECT_EQ(comm_counts.recv_counts, recv_counts);
+//     // EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+//     // EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+// }
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -24,12 +24,6 @@ protected:
 };
 
 
-TEST_F(CommunicationPatternFixture, can_get_comm_size)
-{
-    auto comm = exec->get_gko_mpi_host_comm();
-    EXPECT_EQ(comm->size(), 4);
-}
-
 TEST_F(CommunicationPatternFixture, compute_owner_rank_single_owner)
 {
     auto comm = exec->get_gko_mpi_host_comm();
@@ -39,8 +33,6 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_single_owner)
     // when all ranks have the rank 0 as the owner rank
     EXPECT_EQ(owner_rank, 0);
 }
-
-// TEST_F(CommunicationPatternFixture, com)
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
@@ -90,6 +82,9 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     std::vector<std::vector<int>> recv_offsets_results(comm->size() + 1,
                                           std::vector<int>{0, 0, 0, 0, 0});
     recv_offsets_results[0] = std::vector<int>{0, 10, 20, 30, 40};
+
+    // test if the total number of processes is 4, which is hardcoded here
+    EXPECT_EQ(comm->size(), 4);
 
     // test send counts and revc counts
     EXPECT_EQ(comm_counts.send_counts, send_results[comm->rank()]);

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -76,13 +76,13 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
     // if gathering to just one owner, all 10 elements are send to itself
     std::vector<int> send_counts(comm->size(), 0);
     send_counts[comm->rank()] = num_elements;
-    std::vector<std::vector<int>> send_results(comm->size(), send_counts);
+    std::vector<int> recv_counts(send_counts);
     
     // all offsets should be zero
     // last entry in offsets is total number of send elements
     std::vector<int> send_offsets(comm->size() + 1, 0);
     send_offsets.back() = num_elements;
-    std::vector<std::vector<int>> offset_results(comm->size(), send_offsets);
+    std::vector<int> recv_offsets(send_offsets);
 
     // Act
     auto comm_counts =
@@ -90,12 +90,12 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 
     // Assert
     // test send counts and revc counts
-    EXPECT_EQ(comm_counts.send_counts, send_results[comm->rank()]);
-    EXPECT_EQ(comm_counts.recv_counts, send_results[comm->rank()]);
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
 
-    // test send offsets and revc offsets
-    EXPECT_EQ(comm_counts.send_offsets, offset_results[comm->rank()]);
-    EXPECT_EQ(comm_counts.recv_offsets, offset_results[comm->rank()]);
+    // test send counts and revc offsets
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
 // Given 4 processes in the communicator

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -66,38 +66,6 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_all_owners)
     EXPECT_EQ(owner_rank, comm_rank);
 }
 
-TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
-{
-    // Arrange
-    auto comm = exec->get_gko_mpi_host_comm();
-    auto num_elements = 10;
-
-    // expected results
-    // if gathering to just one owner, all 10 elements are send to itself
-    std::vector<int> send_counts(comm->size(), 0);
-    send_counts[comm->rank()] = num_elements;
-    std::vector<int> recv_counts(send_counts);
-    
-    // all offsets should be zero
-    // last entry in offsets is total number of send elements
-    std::vector<int> send_offsets(comm->size() + 1, 0);
-    send_offsets.back() = num_elements;
-    std::vector<int> recv_offsets(send_offsets);
-
-    // Act
-    auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), 1, label(num_elements));
-
-    // Assert
-    // test send counts and revc counts
-    EXPECT_EQ(comm_counts.send_counts, send_counts);
-    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
-
-    // test send counts and revc offsets
-    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
-    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
-}
-
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {
     // Arrange
@@ -140,6 +108,37 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
+TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
+{
+    // Arrange
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
+
+    // expected results
+    // if gathering to just one owner, all 10 elements are send to itself
+    std::vector<int> send_counts(comm->size(), 0);
+    send_counts[comm->rank()] = num_elements;
+    std::vector<int> recv_counts(send_counts);
+    
+    // all offsets should be zero
+    // last entry in offsets is total number of send elements
+    std::vector<int> send_offsets(comm->size() + 1, 0);
+    send_offsets.back() = num_elements;
+    std::vector<int> recv_offsets(send_offsets);
+
+    // Act
+    auto comm_counts =
+        compute_gather_to_owner_counts(*exec.get(), 1, label(num_elements));
+
+    // Assert
+    // test send counts and revc counts
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
+
+    // test send counts and revc offsets
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+}
 int main(int argc, char *argv[])
 {
     int result = 0;

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -103,25 +103,26 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {
     // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
 
-    // if gathering to just one owner all 10 elements are send to rank 0
+    // if gathering to just one owner, all 10 elements are send to rank 0
     std::vector<std::vector<int>> send_results(comm->size(),
-                                          std::vector<int>{10, 0, 0, 0});
+                                          std::vector<int>{num_elements, 0, 0, 0});
     // no rank should recv anything except rank 0
     std::vector<std::vector<int>> recv_results(comm->size(),
                                           std::vector<int>{0, 0, 0, 0});
-    recv_results[0] = std::vector<int>{10, 10, 10, 10};
+    recv_results[0] = std::vector<int>{num_elements, num_elements, num_elements, num_elements};
 
     std::vector<std::vector<int>> send_offsets_results(comm->size() + 1,
-                                          std::vector<int>{0, 0, 0, 0, 10});
+                                          std::vector<int>{0, 0, 0, 0, num_elements});
 
     std::vector<std::vector<int>> recv_offsets_results(comm->size() + 1,
                                           std::vector<int>{0, 0, 0, 0, 0});
-    recv_offsets_results[0] = std::vector<int>{0, 10, 20, 30, 40};
+    recv_offsets_results[0] = std::vector<int>{0, num_elements, num_elements*2, num_elements*3, num_elements*4};
 
     // Act
     auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), comm->size(), label(10));
+        compute_gather_to_owner_counts(*exec.get(), comm->size(), label(num_elements));
 
     // Assert
     // test if the total number of processes is 4, which is hardcoded here

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -48,6 +48,16 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_two_owners)
         EXPECT_EQ(owner_rank, comm_size/2);
 }
 
+TEST_F(CommunicationPatternFixture, compute_owner_rank_all_owners)
+{
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto comm_rank = comm->rank();
+
+    auto owner_rank = compute_owner_rank(comm_rank, 1);
+
+    EXPECT_EQ(owner_rank, comm_rank);
+}
+
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
     auto comm = exec->get_gko_mpi_host_comm();

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -66,6 +66,45 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_all_owners)
     EXPECT_EQ(owner_rank, comm_rank);
 }
 
+TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_owner)
+{
+    // Arrange
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
+    auto comm_size = comm->size();
+    auto comm_rank = comm->rank();
+
+    // Scatter different number of elements from owner to each non-owner process
+    std::vector<int> send_counts(comm_size);
+    
+    if (comm_rank == 0)
+        for (int i = 0; i < comm_size; i++)
+            send_counts[i] = num_elements*i;
+      
+    std::vector<int> recv_counts(comm_size);
+
+    if (comm_rank != 0)
+        recv_counts[0] = num_elements*comm_rank;
+
+    std::vector<int> send_offsets(comm_size);
+    if (comm_rank == 0)
+        for (int i = 0; i < comm_size-1; i++)
+            send_offsets[i+1] = send_offsets[i] + num_elements*i;
+    
+    std::vector<int> recv_offsets(comm_size);
+
+    // Act
+    auto comm_counts =
+        compute_scatter_from_owner_counts(*exec.get(), comm_size, label(num_elements * comm_rank)); 
+
+    // Assert
+    // test send counts and revc counts
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+}
+
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {
     // Arrange
@@ -92,7 +131,7 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     std::vector<int> recv_offsets(comm_size+1);
     if (comm_rank == 0)
     {
-        for (int i = 0; i < comm_size+1; i++)
+        for (int i = 0; i < comm_size; i++)
         {
             recv_offsets[i+1] = recv_offsets[i] + num_elements*i;
         }

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -70,22 +70,23 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
     // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
 
     // expected results
     // if gathering to just one owner, all 10 elements are send to itself
     std::vector<int> send_counts(comm->size(), 0);
-    send_counts[comm->rank()] = 10;
+    send_counts[comm->rank()] = num_elements;
     std::vector<std::vector<int>> send_results(comm->size(), send_counts);
     
     // all offsets should be zero
     // last entry in offsets is total number of send elements
     std::vector<int> send_offsets(comm->size() + 1, 0);
-    send_offsets.back() = 10;
+    send_offsets.back() = num_elements;
     std::vector<std::vector<int>> offset_results(comm->size(), send_offsets);
 
     // Act
     auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), 1, label(10));
+        compute_gather_to_owner_counts(*exec.get(), 1, label(num_elements));
 
     // Assert
     // test send counts and revc counts

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -57,9 +57,13 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_two_owners)
 
     // Assert
     if (comm_rank < comm_size/2)
+    {
         EXPECT_EQ(owner_rank, 0);
+    }
     else
+    {
         EXPECT_EQ(owner_rank, comm_size/2);
+    }
 }
 
 TEST_F(CommunicationPatternFixture, compute_owner_rank_all_owners)
@@ -87,18 +91,24 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     std::vector<int> send_counts(comm_size);
     
     if (comm_rank == 0)
+    {
         for (int i = 0; i < comm_size; i++)
+        {
             send_counts[i] = num_elements*i;
-
+        }
+    }
     std::vector<int> recv_counts(comm_size);
 
     recv_counts[0] = num_elements*comm_rank;
 
     std::vector<int> send_offsets(comm_size+1);
     if (comm_rank == 0)
+    {
         for (int i = 0; i < comm_size; i++)
+        {
             send_offsets[i+1] = send_offsets[i] + num_elements*i;
-    
+        }
+    }
     std::vector<int> recv_offsets(comm_size+1);
     recv_offsets.back() = num_elements * comm_rank;
 
@@ -109,8 +119,8 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     // Assert
     EXPECT_EQ(comm_counts.send_counts, send_counts);
     EXPECT_EQ(comm_counts.recv_counts, recv_counts);
-    // EXPECT_EQ(comm_counts.send_offsets, send_offsets);
-    // EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
 
@@ -172,11 +182,12 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     // no rank should receive anything except the owner prcocess (rank 0)
     std::vector<int> recv_counts(comm_size) ;
     if (comm_rank == 0)
+    {
         for (int i = 0; i < comm_size; i++)
         {
             recv_counts[i] = num_elements*i;
         }
-  
+    }
     std::vector<int> send_offsets(comm_size+1);
     send_offsets.back() = num_elements * comm_rank;
 
@@ -214,20 +225,28 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_two_owners)
     // Expected results for send counts and recv counts
     std::vector<int> send_counts(comm_size, 0);
     if (comm_rank < comm_size/2)
+    {
         send_counts[0] = num_elements;
+    }
     else
+    {
         send_counts[comm_size/2] = num_elements;
-    
+    }
+
     std::vector<int> recv_counts(comm_size, 0);
     if (comm_rank == 0)
     {
         for (int i = 0; i < comm_size/2; i++)
+        {
             recv_counts[i] = num_elements;
+        }
     }
     else if (comm_rank == comm_size/2)
     {
         for (int i = comm_size/2; i < comm_size; i++)
+        {
             recv_counts[i] = num_elements;
+        }
     }        
     
     // Expected results for send offsets and recv offsets
@@ -238,15 +257,17 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_two_owners)
     if (comm_rank == 0)
     {
         for (int i = 0; i < comm_size/2; i++)
+        {
             recv_offsets[i] = num_elements * i;
-        
+        }
         recv_offsets.back() = num_elements * comm_size/2;
     }
     else if (comm_rank == comm_size/2)
     {
         for (int i = comm_size/2, j = 0; i < comm_size; i++, j++)
+        {
             recv_offsets[i] = num_elements * j;
-        
+        }
         recv_offsets.back() = num_elements * comm_size/2;
     }
 

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -26,22 +26,27 @@ protected:
 
 TEST_F(CommunicationPatternFixture, compute_owner_rank_single_owner)
 {
+    // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
+
+    // Act
     auto owner_rank = compute_owner_rank(comm->rank(), comm->size());
 
-    // if ranks_per_owner is same as total number of ranks all ranks have
-    // when all ranks have the rank 0 as the owner rank
+    // Assert
     EXPECT_EQ(owner_rank, 0);
 }
 
 TEST_F(CommunicationPatternFixture, compute_owner_rank_two_owners)
 {
+    // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
     auto comm_rank = comm->rank();
     auto comm_size = comm->size();
 
+    // Act
     auto owner_rank = compute_owner_rank(comm_rank, comm_size/2);
 
+    // Assert
     if (comm_rank < comm_size/2)
         EXPECT_EQ(owner_rank, 0);
     else
@@ -50,22 +55,24 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_two_owners)
 
 TEST_F(CommunicationPatternFixture, compute_owner_rank_all_owners)
 {
+    // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
     auto comm_rank = comm->rank();
 
+    // Act
     auto owner_rank = compute_owner_rank(comm_rank, 1);
 
+    // Assert
     EXPECT_EQ(owner_rank, comm_rank);
 }
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
+    // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
-    auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), 1, label(10));
 
     // expected results
-    // if gathering to just one owner all 10 elements are send to it self
+    // if gathering to just one owner, all 10 elements are send to itself
     std::vector<int> send_counts(comm->size(), 0);
     send_counts[comm->rank()] = 10;
     std::vector<std::vector<int>> send_results(comm->size(), send_counts);
@@ -76,6 +83,11 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
     send_offsets.back() = 10;
     std::vector<std::vector<int>> offset_results(comm->size(), send_offsets);
 
+    // Act
+    auto comm_counts =
+        compute_gather_to_owner_counts(*exec.get(), 1, label(10));
+
+    // Assert
     // test send counts and revc counts
     EXPECT_EQ(comm_counts.send_counts, send_results[comm->rank()]);
     EXPECT_EQ(comm_counts.recv_counts, send_results[comm->rank()]);
@@ -85,12 +97,11 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
     EXPECT_EQ(comm_counts.recv_offsets, offset_results[comm->rank()]);
 }
 
-
+// Given 4 processes in the communicator
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {
+    // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
-    auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), comm->size(), label(10));
 
     // if gathering to just one owner all 10 elements are send to rank 0
     std::vector<std::vector<int>> send_results(comm->size(),
@@ -107,6 +118,11 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
                                           std::vector<int>{0, 0, 0, 0, 0});
     recv_offsets_results[0] = std::vector<int>{0, 10, 20, 30, 40};
 
+    // Act
+    auto comm_counts =
+        compute_gather_to_owner_counts(*exec.get(), comm->size(), label(10));
+
+    // Assert
     // test if the total number of processes is 4, which is hardcoded here
     EXPECT_EQ(comm->size(), 4);
 

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -108,7 +108,65 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
-TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
+TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_two_owners)
+{
+    // Arrange
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
+    auto comm_rank = comm->rank();
+    auto comm_size = comm->size();
+
+    // Expected results for send counts and recv counts
+    std::vector<int> send_counts(comm_size, 0);
+    if (comm_rank < comm_size/2)
+        send_counts[0] = num_elements;
+    else
+        send_counts[comm_size/2] = num_elements;
+    
+    std::vector<int> recv_counts(comm_size, 0);
+    if (comm_rank == 0)
+    {
+        for (int i = 0; i < comm_size/2; i++)
+            recv_counts[i] = num_elements;
+    }
+    else if (comm_rank == comm_size/2)
+    {
+        for (int i = comm_size/2; i < comm_size; i++)
+            recv_counts[i] = num_elements;
+    }        
+    
+    // Expected results for send offsets and recv offsets
+    std::vector<int> send_offsets(comm_size + 1, 0);
+    send_offsets.back() = num_elements;
+
+    std::vector<int> recv_offsets(comm_size + 1, 0);
+    if (comm_rank == 0)
+    {
+        for (int i = 0; i < comm_size/2; i++)
+            recv_offsets[i] = num_elements * i;
+        
+        recv_offsets.back() = num_elements * comm_size/2;
+    }
+    else if (comm_rank == comm_size/2)
+    {
+        for (int i = comm_size/2, j = 0; i < comm_size; i++, j++)
+            recv_offsets[i] = num_elements * j;
+        
+        recv_offsets.back() = num_elements * comm_size/2;
+    }
+
+    // Act
+    auto comm_counts =
+        compute_gather_to_owner_counts(*exec.get(), comm_size/2, label(num_elements));
+
+    // Assert
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+}
+
+TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owners)
 {
     // Arrange
     auto comm = exec->get_gko_mpi_host_comm();

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -8,6 +8,8 @@
 
 #include "mpi.h"
 
+#include <cstdlib>
+
 class CommunicationPatternFixture : public testing::Test {
 protected:
     CommunicationPatternFixture()
@@ -15,6 +17,13 @@ protected:
     {
         dict.add("executor", "reference");
         exec = std::make_shared<ExecutorHandler>(db, dict, "dummy", true);
+       
+        auto comm = exec->get_gko_mpi_host_comm();
+        if (comm->size() < 2)
+        {
+            std::cout << "At least 2 CPU processes should be used!" << std::endl;
+            std::abort();
+        }  
     }
 
     const Foam::Time *time;
@@ -100,8 +109,8 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     // Assert
     EXPECT_EQ(comm_counts.send_counts, send_counts);
     EXPECT_EQ(comm_counts.recv_counts, recv_counts);
-    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
-    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+    // EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    // EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
 

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -34,6 +34,20 @@ TEST_F(CommunicationPatternFixture, compute_owner_rank_single_owner)
     EXPECT_EQ(owner_rank, 0);
 }
 
+TEST_F(CommunicationPatternFixture, compute_owner_rank_two_owners)
+{
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto comm_rank = comm->rank();
+    auto comm_size = comm->size();
+
+    auto owner_rank = compute_owner_rank(comm_rank, comm_size/2);
+
+    if (comm_rank < comm_size/2)
+        EXPECT_EQ(owner_rank, 0);
+    else
+        EXPECT_EQ(owner_rank, comm_size/2);
+}
+
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
     auto comm = exec->get_gko_mpi_host_comm();

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -30,25 +30,30 @@ TEST_F(CommunicationPatternFixture, can_get_comm_size)
     EXPECT_EQ(comm->size(), 4);
 }
 
-TEST_F(CommunicationPatternFixture, compute_owner_rank)
+TEST_F(CommunicationPatternFixture, compute_owner_rank_single_owner)
 {
     auto comm = exec->get_gko_mpi_host_comm();
     auto owner_rank = compute_owner_rank(comm->rank(), comm->size());
+
     // if ranks_per_owner is same as total number of ranks all ranks have
     // when all ranks have the rank 0 as the owner rank
     EXPECT_EQ(owner_rank, 0);
 }
+
+// TEST_F(CommunicationPatternFixture, com)
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_all_owner)
 {
     auto comm = exec->get_gko_mpi_host_comm();
     auto comm_counts =
         compute_gather_to_owner_counts(*exec.get(), 1, label(10));
+
     // expected results
     // if gathering to just one owner all 10 elements are send to it self
     std::vector<int> send_counts(comm->size(), 0);
     send_counts[comm->rank()] = 10;
     std::vector<std::vector<int>> send_results(comm->size(), send_counts);
+    
     // all offsets should be zero
     // last entry in offsets is total number of send elements
     std::vector<int> send_offsets(comm->size() + 1, 0);

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -78,7 +78,7 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     std::vector<int> send_counts(comm_size);
     
     if (comm_rank == 0)
-        for (int i = 0; i < comm_size; i++)
+        for (int i = 1; i < comm_size; i++)
             send_counts[i] = num_elements*i;
       
     std::vector<int> recv_counts(comm_size);
@@ -104,6 +104,7 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     EXPECT_EQ(comm_counts.send_offsets, send_offsets);
     EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
+
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -123,49 +123,73 @@ TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_single_own
     EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
+TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_two_owners)
+{
+    // Arrange
+    auto comm = exec->get_gko_mpi_host_comm();
+    auto num_elements = 10;
+    auto comm_size = comm->size();
+    auto comm_rank = comm->rank();
 
-// TEST_F(CommunicationPatternFixture, compute_scatter_from_owner_counts_two_owners)
-// {
-//     // Arrange
-//     auto comm = exec->get_gko_mpi_host_comm();
-//     auto num_elements = 10;
-//     auto comm_size = comm->size();
-//     auto comm_rank = comm->rank();
-
-//     // Scatter different number of elements from owner to each non-owner process
-//     std::vector<int> send_counts(comm_size);
+    // Scatter different number of elements from owner to each non-owner process
+    std::vector<int> send_counts(comm_size);
     
-//     if (comm_rank == 0)
-//         for (int i = 1; i < comm_size/2; i++)
-//             send_counts[i] = num_elements*i;
-    
-//     if (comm_rank == comm_size/2)
-//         for (int i = comm_size/2 + 1; i < comm_size; i++)
-//             send_counts[i] = num_elements*i;
-      
-//     // std::vector<int> recv_counts(comm_size);
+    if (comm_rank == 0)
+    {
+        for (int i = 0; i < comm_size/2; i++)
+        {
+            send_counts[i] = num_elements*i;
+        }
+    }
+    else if (comm_rank == comm_size/2)
+    {
+        for (int i = comm_size/2; i < comm_size; i++)
+        {
+            send_counts[i] = num_elements*i;
+        }
+    }  
 
-//     // if (comm_rank != 0)
-//     //     recv_counts[0] = num_elements*comm_rank;
+    std::vector<int> recv_counts(comm_size);
 
-//     // std::vector<int> send_offsets(comm_size);
-//     // if (comm_rank == 0)
-//     //     for (int i = 0; i < comm_size-1; i++)
-//     //         send_offsets[i+1] = send_offsets[i] + num_elements*i;
-    
-//     // std::vector<int> recv_offsets(comm_size);
+    if (comm_rank < comm_size/2)
+    {
+        recv_counts[0] = num_elements*comm_rank;
+    }
+    else if (comm_rank < comm_size)
+    {
+        recv_counts[comm_size/2] = num_elements*comm_rank;
+    }
 
-//     // Act
-//     auto comm_counts =
-//         compute_scatter_from_owner_counts(*exec.get(), comm_size/2, label(num_elements * comm_rank)); 
+    std::vector<int> send_offsets(comm_size+1);
+    if (comm_rank == 0)
+    {
+        for (int i = 0; i < comm_size/2-1; i++)
+        {
+            send_offsets[i+1] = send_offsets[i] + num_elements*i;
+        }
+        send_offsets.back() = send_offsets[comm_size/2-1] + send_counts[comm_size/2-1];
+    }
+    else if (comm_rank == comm_size/2)
+    {
+        for (int i = comm_size/2; i < comm_size; i++)
+        {
+            send_offsets[i+1] = send_offsets[i] + num_elements*i;
+        }
+    }
 
-//     // Assert
-//     // test send counts and revc counts
-//     EXPECT_EQ(comm_counts.send_counts, send_counts);
-//     // EXPECT_EQ(comm_counts.recv_counts, recv_counts);
-//     // EXPECT_EQ(comm_counts.send_offsets, send_offsets);
-//     // EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
-// }
+    std::vector<int> recv_offsets(comm_size+1);
+    recv_offsets.back() = num_elements * comm_rank;
+
+    // Act
+    auto comm_counts =
+        compute_scatter_from_owner_counts(*exec.get(), comm_size/2, label(num_elements * comm_rank)); 
+
+    // Assert
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
+}
 
 TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
 {

--- a/unitTests/CommunicationPattern.C
+++ b/unitTests/CommunicationPattern.C
@@ -104,37 +104,38 @@ TEST_F(CommunicationPatternFixture, compute_gather_to_owner_counts_single_owner)
     // Arrange
     auto comm = exec->get_gko_mpi_host_comm();
     auto num_elements = 10;
+    auto comm_size = comm->size();
 
     // if gathering to just one owner, all 10 elements are send to rank 0
-    std::vector<std::vector<int>> send_results(comm->size(),
-                                          std::vector<int>{num_elements, 0, 0, 0});
+    std::vector<int> send_counts{num_elements, 0, 0, 0};
+ 
     // no rank should recv anything except rank 0
-    std::vector<std::vector<int>> recv_results(comm->size(),
-                                          std::vector<int>{0, 0, 0, 0});
-    recv_results[0] = std::vector<int>{num_elements, num_elements, num_elements, num_elements};
+    std::vector<int> recv_counts(comm_size) ;
+    if (comm->rank() == 0)
+        recv_counts = std::vector<int>(comm_size, num_elements);
+  
+    std::vector<int> send_offsets(comm_size+1);
+    send_offsets[comm_size] = num_elements;
 
-    std::vector<std::vector<int>> send_offsets_results(comm->size() + 1,
-                                          std::vector<int>{0, 0, 0, 0, num_elements});
-
-    std::vector<std::vector<int>> recv_offsets_results(comm->size() + 1,
-                                          std::vector<int>{0, 0, 0, 0, 0});
-    recv_offsets_results[0] = std::vector<int>{0, num_elements, num_elements*2, num_elements*3, num_elements*4};
+    std::vector<int> recv_offsets(comm_size+1);
+    if (comm->rank() == 0)
+    recv_offsets = std::vector<int>{0, num_elements, num_elements*2, num_elements*3, num_elements*4};
 
     // Act
     auto comm_counts =
-        compute_gather_to_owner_counts(*exec.get(), comm->size(), label(num_elements));
+        compute_gather_to_owner_counts(*exec.get(), comm_size, label(num_elements));
 
     // Assert
     // test if the total number of processes is 4, which is hardcoded here
-    EXPECT_EQ(comm->size(), 4);
+    EXPECT_EQ(comm_size, 4);
 
     // test send counts and revc counts
-    EXPECT_EQ(comm_counts.send_counts, send_results[comm->rank()]);
-    EXPECT_EQ(comm_counts.recv_counts, recv_results[comm->rank()]);
+    EXPECT_EQ(comm_counts.send_counts, send_counts);
+    EXPECT_EQ(comm_counts.recv_counts, recv_counts);
 
-    // test send offsets and revc offsets
-    EXPECT_EQ(comm_counts.send_offsets, send_offsets_results[comm->rank()]);
-    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets_results[comm->rank()]);
+    // test send counts and revc offsets
+    EXPECT_EQ(comm_counts.send_offsets, send_offsets);
+    EXPECT_EQ(comm_counts.recv_offsets, recv_offsets);
 }
 
 int main(int argc, char *argv[])

--- a/unitTests/HostMatrix.C
+++ b/unitTests/HostMatrix.C
@@ -206,9 +206,6 @@ int main(int argc, char *argv[])
 
     ::testing::InitGoogleTest(&argc, argv);
 
-    std::shared_ptr<const ExecutorHandler> exec =
-        ((HostMatrixEnvironment *)global_env)->exec;
-
     my_argc = argc;
     my_argv = argv;
 


### PR DESCRIPTION
Add new unit tests for the following functions
-  `compute_owner_rank` 
- `compute_gather_to_owner_counts`
- `compute_scatter_from_owner_counts`

Refactor original unit tests for the function `compute_gather_to_owner_counts`

The unit tests can run on any arbitrary even number of CPU processes.